### PR TITLE
Add API keys to User

### DIFF
--- a/aiof.auth.data/AuthContext.cs
+++ b/aiof.auth.data/AuthContext.cs
@@ -33,6 +33,8 @@ namespace aiof.auth.data
                 e.Property(x => x.Email).HasSnakeCaseColumnName().HasMaxLength(200).IsRequired();
                 e.Property(x => x.Username).HasSnakeCaseColumnName().HasMaxLength(200).IsRequired();
                 e.Property(x => x.Password).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
+                e.Property(x => x.PrimaryApiKey).HasSnakeCaseColumnName().HasMaxLength(100);
+                e.Property(x => x.SecondaryApiKey).HasSnakeCaseColumnName().HasMaxLength(100);
                 e.Property(x => x.Created).HasColumnType("timestamp").HasSnakeCaseColumnName().IsRequired();
             });
 

--- a/aiof.auth.data/ClientRefreshToken.cs
+++ b/aiof.auth.data/ClientRefreshToken.cs
@@ -8,7 +8,7 @@ namespace aiof.auth.data
     {
         [JsonIgnore] public int Id { get; set; }
         [JsonIgnore] public Guid PublicKey { get; set; } = Guid.NewGuid();
-        public string Token { get; set; } = Utils.GenerateApiKey(64);
+        public string Token { get; set; } = Utils.GenerateApiKey<ClientRefreshToken>(64);
         public int ClientId { get; set; }
         [JsonIgnore] public Client Client { get; set; }
         public DateTime Created { get; set; } = DateTime.UtcNow;

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -68,8 +68,8 @@ namespace aiof.auth.data
                     Name = "GK Client 1",
                     Slug = "gk-client-1",
                     Enabled = true,
-                    PrimaryApiKey = "gk-client-1-p-key",
-                    SecondaryApiKey = "gk-client-1-s-key"
+                    PrimaryApiKey = "Q2xpZW50.YJj7MeyO1P9DpglkO8bFeAe6vYEBrFhpC9O6BrYR43w=",
+                    SecondaryApiKey = "Q2xpZW50.k3HO3GHyDpO0InUUWzzOUrs52Mt6tEdkq7MuTokH0M8="
                 },
                 new Client
                 {
@@ -78,8 +78,8 @@ namespace aiof.auth.data
                     Name = "GK Client 2",
                     Slug = "gk-client-2",
                     Enabled = true,
-                    PrimaryApiKey = "gk-client-2-p-key",
-                    SecondaryApiKey = "gk-client-2-s-key"
+                    PrimaryApiKey = "Q2xpZW50.Jo9C+6F3no9pwg8s1OWDkUGs+wHAVbsWkcRTS0s/SjU=",
+                    SecondaryApiKey = "Q2xpZW50.FAe44G9HIrbDFCGa/ZF4xZE+m3Fne7cB7eNJuy2vcoc="
                 },
                 new Client
                 {
@@ -88,8 +88,8 @@ namespace aiof.auth.data
                     Name = "GK Client 3",
                     Slug = "gk-client-3",
                     Enabled = false,
-                    PrimaryApiKey = "gk-client-3-p-key",
-                    SecondaryApiKey = "gk-client-3-s-key"
+                    PrimaryApiKey = "Q2xpZW50.Dpkt/TSLB+nlVyQwi/pSUhkwEglerntGUym6h+3DM/k=",
+                    SecondaryApiKey = "Q2xpZW50.5/fRn0AL2RYPHcrT73HCSIuIYm2Iew5+1v9nvtXrtE4="
                 }
             };
         }

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -185,7 +185,8 @@ namespace aiof.auth.data
             bool firstName = false,
             bool lastName = false,
             bool email = false,
-            bool username = false)
+            bool username = false,
+            bool apiKeys = false)
         {
             var fakeUsers = GetFakeUsers()
                 .ToArray();
@@ -227,6 +228,15 @@ namespace aiof.auth.data
                     toReturn.Add(new object[] 
                     { 
                         fakeUserPublicKey
+                    });
+                }
+            else if (apiKeys)
+                foreach (var fakeUser in fakeUsers
+                    .Where(x => x.PrimaryApiKey != null && x.SecondaryApiKey != null))
+                {
+                    toReturn.Add(new object[] 
+                    { 
+                        fakeUser.PrimaryApiKey, fakeUser.SecondaryApiKey
                     });
                 }
 

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -53,6 +53,18 @@ namespace aiof.auth.data
                     Email = "jessie@test.com",
                     Username = "jbro",
                     Password = "10000.nBfnY+XzDhvP7Z2RcTLTtA==.rj6rCGGLRz5bvTxZj+cB8X+GbYf1nTu0x9iW2v3wEYc=" //password123
+                },
+                new User
+                {
+                    Id = 3,
+                    PublicKey = Guid.Parse("7c135230-2889-4cbb-bb0e-ab4237d89367"),
+                    FirstName = "George",
+                    LastName = "Best",
+                    Email = "george.best@auth.com",
+                    Username = "gbest",
+                    Password = "10000.JiFzc3Ijb5vBrCb8COiNzA==.BzdHomm3RMu0sMHaBfTpY0B2WtbjFqi9tN7T//N+khA=", //pass1234
+                    PrimaryApiKey = "VXNlcg==.x0sHnNHFytELB6FkLb/L6Q/YXPoXAZ4bAHvztgr6vIU=",
+                    SecondaryApiKey = "VXNlcg==.VmNKkE4o6zxCq8Ut1BzkSU2R7RcCqo8y/jTklcTU6m8="
                 }
             };
         }

--- a/aiof.auth.data/IUser.cs
+++ b/aiof.auth.data/IUser.cs
@@ -35,6 +35,16 @@ namespace aiof.auth.data
         [Required]
         [MaxLength(100)]
         string Password { get; set; }
+        
+        [JsonIgnore]
+        [Required]
+        [MaxLength(100)]
+        string PrimaryApiKey { get; set; }
+
+        [JsonIgnore]
+        [Required]
+        [MaxLength(100)]
+        string SecondaryApiKey { get; set; }
 
         [Required]
         DateTime Created { get; set; }

--- a/aiof.auth.data/Keys.cs
+++ b/aiof.auth.data/Keys.cs
@@ -67,12 +67,17 @@ namespace aiof.auth.data
         public static string Base<T>(int id)
             where T : IPublicKeyId
         {
-            return $"{typeof(T).Name.ToLower()}.id.{id}";
+            return $"{typeof(T).Name.ToLowerInvariant()}.id.{id}";
+        }
+        public static string Base<T>(Guid publicKey)
+            where T : IPublicKeyId
+        {
+            return $"{typeof(T).Name.ToLowerInvariant()}.publicKey.{publicKey}";
         }
         public static string Base<T>(string apiKey)
             where T : IApiKey
         {
-            return $"{typeof(T).Name.ToLower()}.apikey.{apiKey}";
+            return $"{typeof(T).Name.ToLowerInvariant()}.apikey.{apiKey}";
         }
 
         public static string User(string username)

--- a/aiof.auth.data/TokenRequest.cs
+++ b/aiof.auth.data/TokenRequest.cs
@@ -77,8 +77,8 @@ namespace aiof.auth.data
 
     public enum TokenType
     {
-        Client = 1,
-        Refresh = 2,
-        User = 3
+        User,
+        ApiKey,
+        Refresh,
     }
 }

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -14,6 +14,8 @@ namespace aiof.auth.data
         public string Email { get; set; }
         public string Username { get; set; }
         [JsonIgnore] public string Password { get; set; }
+        [JsonIgnore] public string PrimaryApiKey { get; set; }
+        [JsonIgnore] public string SecondaryApiKey { get; set; }
         public DateTime Created { get; set; } = DateTime.UtcNow;
     }
 

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 namespace aiof.auth.data
 {
     public class User : IUser, 
-        IPublicKeyId
+        IPublicKeyId, IApiKey
     {
         [JsonIgnore] public int Id { get; set; }
         [JsonIgnore] public Guid PublicKey { get; set; } = Guid.NewGuid();

--- a/aiof.auth.data/Utils.cs
+++ b/aiof.auth.data/Utils.cs
@@ -19,12 +19,11 @@ namespace aiof.auth.data
             var key = new byte[length];
             using (var generator = RandomNumberGenerator.Create())
                 generator.GetBytes(key);
-            var tkey = Encoding.ASCII.GetBytes(typeof(T).Name.ToLowerInvariant());
-            return $"{Convert.ToBase64String(tkey)}.{Convert.ToBase64String(key)}";
+            return $"{typeof(T).Name.Base64Encode()}.{Convert.ToBase64String(key)}";
         }
 
         public static Client GenerateApiKeys(
-            [NotNull] this Client client, 
+            [NotNull] this Client client,
             int length = 32)
         {
             client.PrimaryApiKey = GenerateApiKey<Client>(length);
@@ -33,16 +32,25 @@ namespace aiof.auth.data
             return client;
         }
 
-        public static Type DecodeApiKey<T>(this string apiKey)
-            where T : class
+        public static string DecodeApiKey(
+            [NotNull] this string apiKey)
         {
-            var apiKeyEntity = apiKey.Split('.').First();
-            
-            if (apiKeyEntity == nameof(T).ToLowerInvariant())
-                return typeof(T);
-            else
-                throw new AuthFriendlyException(HttpStatusCode.BadRequest,
-                    $"Error");
+            return apiKey.Split('.')
+                .First()
+                .Base64Decode();
+        }
+
+        public static string Base64Encode(
+            [NotNull] this string plainText)
+        {
+            var plainTextBytes = Encoding.UTF8.GetBytes(plainText);
+            return Convert.ToBase64String(plainTextBytes);
+        }
+        public static string Base64Decode(
+            [NotNull] this string base64EncodedData)
+        {
+            var base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
+            return Encoding.UTF8.GetString(base64EncodedBytes);
         }
 
         public static string ToSnakeCase(
@@ -68,21 +76,21 @@ namespace aiof.auth.data
 
             return propertyBuilder;
         }
-      
+
         public static T ParseEnum<T>(string value)
         {
-            return (T) Enum.Parse(typeof(T), value, true);
+            return (T)Enum.Parse(typeof(T), value, true);
         }
 
         public static T ToEnum<T>(
             [NotNull] this string value)
         {
-            return (T) Enum.Parse(typeof(T), value, true);
+            return (T)Enum.Parse(typeof(T), value, true);
         }
         public static AlgType ToEnum(
             [NotNull] this string value)
         {
-            return (AlgType) Enum.Parse(typeof(AlgType), value, true);
+            return (AlgType)Enum.Parse(typeof(AlgType), value, true);
         }
     }
 }

--- a/aiof.auth.data/Utils.cs
+++ b/aiof.auth.data/Utils.cs
@@ -54,15 +54,15 @@ namespace aiof.auth.data
         }
 
         public static string ToSnakeCase(
-            [NotNull] this string str)
+            [NotNull] this string value)
         {
-            return string.Concat(str.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToLower();
+            return string.Concat(value.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToLower();
         }
 
         public static string ToHyphenCase(
-            [NotNull] this string str)
+            [NotNull] this string value)
         {
-            return str.Replace(' ', '-').ToLower();
+            return value.Replace(' ', '-').ToLower();
         }
 
         public static PropertyBuilder HasSnakeCaseColumnName(

--- a/aiof.auth.data/Validators/TokenRequestValidator.cs
+++ b/aiof.auth.data/Validators/TokenRequestValidator.cs
@@ -13,7 +13,7 @@ namespace aiof.auth.data
             RuleFor(x => x)
                 .NotNull();
 
-            // Either Username, Password is provided, ApiKey is provided or RefreshToken
+            // Either Username, Password is provided, ApiKey (Client or User) is provided or RefreshToken
             RuleFor(x => x)
                 .Must(x => 
                 {
@@ -30,7 +30,7 @@ namespace aiof.auth.data
                         && string.IsNullOrWhiteSpace(x.Username)
                         && string.IsNullOrWhiteSpace(x.Password))
                     {
-                        x.Type = TokenType.Client;
+                        x.Type = TokenType.ApiKey;
                         return true;
                     }
                     else if (!string.IsNullOrWhiteSpace(x.Token)

--- a/aiof.auth.services/AuthRepository.cs
+++ b/aiof.auth.services/AuthRepository.cs
@@ -58,7 +58,7 @@ namespace aiof.auth.services
                     var user = await _userRepo.GetUserAsync(request.Username, request.Password);
                     return GenerateJwtToken(user);
                 case TokenType.ApiKey:
-                    return await (GenerateJwtTokenAsync(request.ApiKey));
+                    return await GenerateJwtTokenAsync(request.ApiKey);
                 case TokenType.Refresh:
                     var client = (await _clientRepo.GetRefreshTokenAsync(request.Token)).Client;
                     return RefreshToken(client);

--- a/aiof.auth.services/BaseRepository.cs
+++ b/aiof.auth.services/BaseRepository.cs
@@ -168,8 +168,8 @@ namespace aiof.auth.services
         {
             var entity = await GetEntityAsync<T>(id, asNoTracking: false);
 
-            entity.PrimaryApiKey = Utils.GenerateApiKey();
-            entity.SecondaryApiKey = Utils.GenerateApiKey();
+            entity.PrimaryApiKey = Utils.GenerateApiKey<T>();
+            entity.SecondaryApiKey = Utils.GenerateApiKey<T>();
 
             await _context.SaveChangesAsync();
 

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -9,6 +9,7 @@ namespace aiof.auth.services
     {
         Task<IUser> GetUserAsync(int id);
         Task<IUser> GetUserAsync(Guid publicKey);
+        Task<IUser> GetUserAsync(string apiKey);
         Task<IUser> GetUserAsync(string username, string password);
         Task<IUser> GetUserAsync(
             string firstName,

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -54,11 +54,11 @@ namespace aiof.auth.services
 
         public async Task<IUser> GetUserAsync(int id)
         {
-            return await base.GetEntityPublicKeyIdAsync<User>(id);
+            return await base.GetEntityAsync<User>(id);
         }
         public async Task<IUser> GetUserAsync(Guid publicKey)
         {
-            return await base.GetEntityPublicKeyIdAsync<User>(publicKey);
+            return await base.GetEntityAsync<User>(publicKey);
         }
         public async Task<IUser> GetUserAsync(
             string username, 

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -116,7 +116,7 @@ namespace aiof.auth.services
                 throw new AuthFriendlyException(HttpStatusCode.BadRequest,
                     $"{nameof(User)} with Username='{userDto.Username}' already exists");
 
-            var user = await GetUserAsync(userDto) == null
+            var user = await GetUserAsync(userDto) is null
                 ? _mapper.Map<User>(userDto)
                 : throw new AuthFriendlyException(HttpStatusCode.BadRequest,
                     $"User with FirstName='{userDto.FirstName}', " +

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -60,6 +60,10 @@ namespace aiof.auth.services
         {
             return await base.GetEntityAsync<User>(publicKey);
         }
+        public async Task<IUser> GetUserAsync(string apiKey)
+        {
+            return await base.GetEntityAsync<User>(apiKey);
+        }
         public async Task<IUser> GetUserAsync(
             string username, 
             bool asNoTracking = true)
@@ -72,7 +76,7 @@ namespace aiof.auth.services
             string username, 
             string password)
         {
-            var user = await GetUserAsync(username);
+            var user = await GetUserAsync(username, true);
 
             if (!Check(user.Password, password))
                 throw new AuthFriendlyException(HttpStatusCode.BadRequest,

--- a/aiof.auth.tests/Helper.cs
+++ b/aiof.auth.tests/Helper.cs
@@ -113,6 +113,13 @@ namespace aiof.auth.tests
             );
         }
 
+        public static IEnumerable<object[]> UsersApiKeys()
+        {
+            return _Fake.GetFakeUsersData(
+                apiKeys: true
+            );
+        }
+
         public static IEnumerable<object[]> ClientsId()
         {
             return _Fake.GetFakeClientsData(

--- a/aiof.auth.tests/Utils.Tests.cs
+++ b/aiof.auth.tests/Utils.Tests.cs
@@ -73,6 +73,23 @@ namespace aiof.auth.tests
         }
 
         [Theory]
+        [InlineData(nameof(User))]
+        [InlineData(nameof(Client))]
+        [InlineData(nameof(ClientRefreshToken))]
+        public void Base64Encode_Base64Decode_Valid(string str)
+        {
+            var encoded = str.Base64Encode();
+
+            Assert.NotNull(encoded);
+            Assert.Contains("=", encoded);
+
+            var decoded = encoded.Base64Decode();
+
+            Assert.NotNull(decoded);
+            Assert.Equal(str, decoded);
+        }
+
+        [Theory]
         [InlineData(nameof(User.Username))]
         [InlineData(nameof(User.Password))]
         [InlineData(nameof(User.Email))]

--- a/aiof.auth.tests/Utils.Tests.cs
+++ b/aiof.auth.tests/Utils.Tests.cs
@@ -14,7 +14,7 @@ namespace aiof.auth.tests
         [MemberData(nameof(Helper.ApiKeyLength), MemberType = typeof(Helper))]
         public void GenerateApiKey_Valid(int length)
         {
-            var apiKey = Utils.GenerateApiKey(length);
+            var apiKey = Utils.GenerateApiKey<Client>(length);
 
             Assert.NotNull(apiKey);
             Assert.Contains('=', apiKey.ToCharArray());
@@ -42,7 +42,7 @@ namespace aiof.auth.tests
         [MemberData(nameof(Helper.ApiKeyLength), MemberType = typeof(Helper))]
         public void GenerateApiKeys_From_IApiKey(int length)
         {
-            var clientApiKey = new Client { } as IApiKey;
+            var clientApiKey = new Client { };
 
             Assert.Null(clientApiKey.PrimaryApiKey);
             Assert.Null(clientApiKey.SecondaryApiKey);

--- a/aiof.auth.tests/Utils.Tests.cs
+++ b/aiof.auth.tests/Utils.Tests.cs
@@ -64,12 +64,14 @@ namespace aiof.auth.tests
         }
 
         [Theory]
-        [InlineData("Q2xpZW50.K5HYvUuUA1Bd/VCCacBFGyz/0E5Ur8AZh1M7z4G5+C0=")]
-        public void DecodeApiKey_Client_Valid(string apiKey)
+        [MemberData(nameof(Helper.UsersApiKeys), MemberType = typeof(Helper))]
+        public void DecodeApiKey_Users_ApiKey_Valid(string primaryApiKey, string secondaryApiKey)
         {
-            var client = apiKey.DecodeApiKey();
+            var user1 = primaryApiKey.DecodeApiKey();
+            var user2 = secondaryApiKey.DecodeApiKey();
 
-            Assert.Equal(nameof(Client), client);
+            Assert.Equal(nameof(User), user1);
+            Assert.Equal(nameof(User), user2);
         }
 
         [Theory]

--- a/aiof.auth.tests/Utils.Tests.cs
+++ b/aiof.auth.tests/Utils.Tests.cs
@@ -12,9 +12,19 @@ namespace aiof.auth.tests
     {
         [Theory]
         [MemberData(nameof(Helper.ApiKeyLength), MemberType = typeof(Helper))]
-        public void GenerateApiKey_Valid(int length)
+        public void GenerateApiKey_Client_Valid(int length)
         {
             var apiKey = Utils.GenerateApiKey<Client>(length);
+
+            Assert.NotNull(apiKey);
+            Assert.Contains('=', apiKey.ToCharArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.ApiKeyLength), MemberType = typeof(Helper))]
+        public void GenerateApiKey_User_Valid(int length)
+        {
+            var apiKey = Utils.GenerateApiKey<User>(length);
 
             Assert.NotNull(apiKey);
             Assert.Contains('=', apiKey.ToCharArray());

--- a/aiof.auth.tests/Utils.Tests.cs
+++ b/aiof.auth.tests/Utils.Tests.cs
@@ -54,6 +54,15 @@ namespace aiof.auth.tests
         }
 
         [Theory]
+        [InlineData("Q2xpZW50.K5HYvUuUA1Bd/VCCacBFGyz/0E5Ur8AZh1M7z4G5+C0=")]
+        public void DecodeApiKey_Client_Valid(string apiKey)
+        {
+            var client = apiKey.DecodeApiKey();
+
+            Assert.Equal(nameof(Client), client);
+        }
+
+        [Theory]
         [InlineData(nameof(User.Username))]
         [InlineData(nameof(User.Password))]
         [InlineData(nameof(User.Email))]

--- a/aiof.auth.tests/Utils.Tests.cs
+++ b/aiof.auth.tests/Utils.Tests.cs
@@ -81,11 +81,12 @@ namespace aiof.auth.tests
             var encoded = str.Base64Encode();
 
             Assert.NotNull(encoded);
-            Assert.Contains("=", encoded);
+            Assert.True(encoded.Length > 0);
 
             var decoded = encoded.Base64Decode();
 
             Assert.NotNull(decoded);
+            Assert.True(decoded.Length > 0);
             Assert.Equal(str, decoded);
         }
 


### PR DESCRIPTION
The Auth API now supports Users and Client authenticating with Api Keys. Previously, it was only Clients. All within the same `auth/token` endpoint

- Added logic to generate the Api keys with the class name prefixed. The format now is `{base64 encoded class name}.{api key}`
- Added logic to decode that based on the class name and register which one it is with a simple string comparison. From there the appropriate JWT is generated
- Updated `BaseRepository` as all classes supported now inherit the `IPublicKeyId` and `IApiKey` interfaces
- Updated unit tests and fake data
- Ran integration tests