### PR TITLE
Add user refresh token

### DIFF
--- a/aiof.auth.core/Controllers/AuthController.cs
+++ b/aiof.auth.core/Controllers/AuthController.cs
@@ -80,14 +80,29 @@ namespace aiof.auth.core.Controllers
         /// </summary>
         [Authorize]
         [HttpPut]
-        [Route("token/revoke")]
+        [Route("token/client/revoke")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task<IActionResult> RevokeRefreshTokenAsync([FromBody, Required] RevokeRequest request)
+        public async Task<IActionResult> RevokeClientRefreshTokenAsync([FromBody, Required] RevokeClientRequest request)
         {
-            return Ok(await _repo.RevokeTokenAsync(request.ClientId, request.Token));
+            return Ok(await _repo.RevokeTokenAsync(request.Token, clientId: request.ClientId));
+        }
+
+        /// <summary>
+        /// Revoke an existing User refresh token
+        /// </summary>
+        [Authorize]
+        [HttpPut]
+        [Route("token/user/revoke")]
+        [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> RevokeUserRefreshTokenAsync([FromBody, Required] RevokeUserRequest request)
+        {
+            return Ok(await _repo.RevokeTokenAsync(request.Token, userId: request.UserId));
         }
 
         /// <summary>

--- a/aiof.auth.core/Controllers/UserController.cs
+++ b/aiof.auth.core/Controllers/UserController.cs
@@ -73,6 +73,20 @@ namespace aiof.auth.core.Controllers
             return Ok(await _repo.GetUserAsync(username, password));
         }
 
+        [HttpGet]
+        [Route("{id}/refresh/token")]
+        public async Task<IActionResult> GetUserRefreshTokenAsync([FromRoute, Required] int id)
+        {
+            return Ok(await _repo.GetRefreshTokenAsync(id));
+        }
+
+        [HttpGet]
+        [Route("{id}/refresh/tokens")]
+        public async Task<IActionResult> GetUserRefreshTokensAsync([FromRoute, Required] int id)
+        {
+            return Ok(await _repo.GetRefreshTokensAsync(id));
+        }
+
         /// <summary>
         /// Create a User
         /// </summary>

--- a/aiof.auth.core/Controllers/UserController.cs
+++ b/aiof.auth.core/Controllers/UserController.cs
@@ -80,11 +80,9 @@ namespace aiof.auth.core.Controllers
         [Route("{id}/refresh/token")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetUserRefreshTokenAsync(
-            [FromRoute, Required] int id,
-            [FromQuery] bool revoked)
+        public async Task<IActionResult> GetUserRefreshTokenAsync([FromRoute, Required] int id)
         {
-            return Ok(await _repo.GetRefreshTokenAsync(id, revoked));
+            return Ok(await _repo.GetRefreshTokenAsync(id));
         }
 
         /// <summary>
@@ -93,11 +91,9 @@ namespace aiof.auth.core.Controllers
         [HttpGet]
         [Route("{id}/refresh/tokens")]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetUserRefreshTokensAsync(
-            [FromRoute, Required] int id,
-            [FromQuery] bool revoked)
+        public async Task<IActionResult> GetUserRefreshTokensAsync([FromRoute, Required] int id)
         {
-            return Ok(await _repo.GetRefreshTokensAsync(id, revoked));
+            return Ok(await _repo.GetRefreshTokensAsync(id));
         }
 
         /// <summary>

--- a/aiof.auth.core/Controllers/UserController.cs
+++ b/aiof.auth.core/Controllers/UserController.cs
@@ -73,18 +73,31 @@ namespace aiof.auth.core.Controllers
             return Ok(await _repo.GetUserAsync(username, password));
         }
 
+        /// <summary>
+        /// Get a User first non-revoked refresh token
+        /// </summary>
         [HttpGet]
         [Route("{id}/refresh/token")]
-        public async Task<IActionResult> GetUserRefreshTokenAsync([FromRoute, Required] int id)
+        [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetUserRefreshTokenAsync(
+            [FromRoute, Required] int id,
+            [FromQuery] bool revoked)
         {
-            return Ok(await _repo.GetRefreshTokenAsync(id));
+            return Ok(await _repo.GetRefreshTokenAsync(id, revoked));
         }
 
+        /// <summary>
+        /// Get a User refresh tokens
+        /// </summary>
         [HttpGet]
         [Route("{id}/refresh/tokens")]
-        public async Task<IActionResult> GetUserRefreshTokensAsync([FromRoute, Required] int id)
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetUserRefreshTokensAsync(
+            [FromRoute, Required] int id,
+            [FromQuery] bool revoked)
         {
-            return Ok(await _repo.GetRefreshTokensAsync(id));
+            return Ok(await _repo.GetRefreshTokensAsync(id, revoked));
         }
 
         /// <summary>

--- a/aiof.auth.core/Controllers/UtilController.cs
+++ b/aiof.auth.core/Controllers/UtilController.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.DataAnnotations;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authorization;
 
 using aiof.auth.data;
 
@@ -14,6 +15,7 @@ namespace aiof.auth.core.Controllers
     /// <summary>
     /// Everything utility
     /// </summary>
+    [AllowAnonymous]
     [ApiController]
     [Route("util")]
     [Produces(Keys.ApplicationJson)]

--- a/aiof.auth.data/AuthContext.cs
+++ b/aiof.auth.data/AuthContext.cs
@@ -8,6 +8,7 @@ namespace aiof.auth.data
     {
         public virtual DbSet<User> Users { get; set; }
         public virtual DbSet<Client> Clients { get; set; }
+        public virtual DbSet<UserRefreshToken> UserRefreshTokens { get; set; }
         public virtual DbSet<ClientRefreshToken> ClientRefreshTokens { get; set; }
         public virtual DbSet<AiofClaim> Claims { get; set; }
 
@@ -52,6 +53,21 @@ namespace aiof.auth.data
                 e.Property(x => x.PrimaryApiKey).HasSnakeCaseColumnName().HasMaxLength(100);
                 e.Property(x => x.SecondaryApiKey).HasSnakeCaseColumnName().HasMaxLength(100);
                 e.Property(x => x.Created).HasColumnType("timestamp").HasSnakeCaseColumnName().IsRequired();
+            });
+
+            modelBuilder.Entity<UserRefreshToken>(e =>
+            {
+                e.ToTable("user_refresh_token");
+
+                e.HasKey(x => x.Id);
+
+                e.Property(x => x.Id).HasSnakeCaseColumnName().ValueGeneratedOnAdd().IsRequired();
+                e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.UserId).HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.Token).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
+                e.Property(x => x.Created).HasColumnType("timestamp").HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.Expires).HasColumnType("timestamp").HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.Revoked).HasColumnType("timestamp").HasSnakeCaseColumnName();
             });
 
             modelBuilder.Entity<ClientRefreshToken>(e =>

--- a/aiof.auth.data/AuthContext.cs
+++ b/aiof.auth.data/AuthContext.cs
@@ -37,6 +37,11 @@ namespace aiof.auth.data
                 e.Property(x => x.PrimaryApiKey).HasSnakeCaseColumnName().HasMaxLength(100);
                 e.Property(x => x.SecondaryApiKey).HasSnakeCaseColumnName().HasMaxLength(100);
                 e.Property(x => x.Created).HasColumnType("timestamp").HasSnakeCaseColumnName().IsRequired();
+
+                e.HasMany(x => x.RefreshTokens)
+                    .WithOne()
+                    .HasForeignKey(x => x.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<Client>(e =>

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -121,6 +121,16 @@ namespace aiof.auth.data
                     UserId = 1,
                     Created = DateTime.UtcNow,
                     Expires = DateTime.UtcNow.AddDays(1)
+                },
+                new UserRefreshToken
+                {
+                    Id = 2,
+                    PublicKey = Guid.Parse("5a1f029f-d692-4148-b6a2-c6a072a71cdf"),
+                    Token = "VXNlcg==.nBpRyGz2l+KtVOJO/Lr74MZs1IVh/Cl7hfE7+OO8V59IZlF+weU6BJiKz1L+sFLROZNyHi76ZPz7ZXOwYnsdXg==",
+                    UserId = 1,
+                    Created = DateTime.UtcNow.AddDays(-2),
+                    Expires = DateTime.UtcNow.AddDays(-1),
+                    Revoked = DateTime.UtcNow.AddDays(-2)
                 }
             };
         }

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -331,6 +331,26 @@ namespace aiof.auth.data
             return toReturn;
         }
 
+        public IEnumerable<object[]> GetFakeUserRefreshTokensData(
+            bool userId = false)
+        {
+            var refreshTokens = GetFakeUserRefreshTokens()
+                .ToArray();
+
+            var toReturn = new List<object[]>();
+
+            if (userId)
+            {
+                foreach (var rtUserId in refreshTokens.Select(x => x.UserId).Distinct())
+                    toReturn.Add(new object[]
+                    {
+                        rtUserId
+                    });
+            }
+
+            return toReturn;
+        }
+
         public IEnumerable<object[]> GetFakeClientRefreshTokensData(
             bool clientId = false,
             bool token = false,

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -125,6 +125,15 @@ namespace aiof.auth.data
                 new UserRefreshToken
                 {
                     Id = 2,
+                    PublicKey = Guid.Parse("427c0b4d-93d9-4868-97bc-54e8852510a7"),
+                    Token = "VXNlcg==.C05sToSVAE4uHZTYchRW2/5/93UHorgcYioAJStqbvahV8jN4MhoygJA3VkrXuwNLfenH7yaHHru/cEkH5Do8g==",
+                    UserId = 1,
+                    Created = DateTime.UtcNow.AddMinutes(-60),
+                    Expires = DateTime.UtcNow.AddMinutes(-60).AddDays(1)
+                },
+                new UserRefreshToken
+                {
+                    Id = 3,
                     PublicKey = Guid.Parse("5a1f029f-d692-4148-b6a2-c6a072a71cdf"),
                     Token = "VXNlcg==.nBpRyGz2l+KtVOJO/Lr74MZs1IVh/Cl7hfE7+OO8V59IZlF+weU6BJiKz1L+sFLROZNyHi76ZPz7ZXOwYnsdXg==",
                     UserId = 1,
@@ -150,7 +159,7 @@ namespace aiof.auth.data
                 },
                 new ClientRefreshToken
                 {
-                    Id = 2,
+                    Id = 3,
                     PublicKey = Guid.Parse("c8f80b28-3459-42b8-9c13-30e719a14df7"),
                     Token = "Q2xpZW50.9hMijUAPRBnEohxLg3z9VZRSefhuBfZs9NgkR3Bf9/r1WG1mupPNCJcdmgGWLBob7fRMCH4JFBJPiahYfQXYdA==",
                     ClientId = 2,

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -341,7 +341,8 @@ namespace aiof.auth.data
         }
 
         public IEnumerable<object[]> GetFakeUserRefreshTokensData(
-            bool userId = false)
+            bool userId = false,
+            bool refreshToken = false)
         {
             var refreshTokens = GetFakeUserRefreshTokens()
                 .ToArray();
@@ -354,6 +355,14 @@ namespace aiof.auth.data
                     toReturn.Add(new object[]
                     {
                         rtUserId
+                    });
+            }
+            else if (refreshToken)
+            {
+                foreach (var token in refreshTokens.Where(x => x.Revoked == null).Select(x => x.Token))
+                    toReturn.Add(new object[]
+                    {
+                        token
                     });
             }
 

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -349,7 +349,17 @@ namespace aiof.auth.data
 
             var toReturn = new List<object[]>();
 
-            if (userId)
+            if (userId
+                && refreshToken)
+            {
+                foreach (var rt in refreshTokens.Where(x => x.Revoked == null))
+                    toReturn.Add(new object[]
+                    {
+                        rt.UserId,
+                        rt.Token
+                    });
+            }
+            else if (userId)
             {
                 foreach (var rtUserId in refreshTokens.Select(x => x.UserId).Distinct())
                     toReturn.Add(new object[]

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -21,6 +21,9 @@ namespace aiof.auth.data
             _context.Clients
                 .AddRange(GetFakeClients());
 
+            _context.UserRefreshTokens
+                .AddRange(GetFakeUserRefreshTokens());
+
             _context.ClientRefreshTokens
                 .AddRange(GetFakeClientRefreshTokens());
 
@@ -102,6 +105,22 @@ namespace aiof.auth.data
                     Enabled = false,
                     PrimaryApiKey = "Q2xpZW50.Dpkt/TSLB+nlVyQwi/pSUhkwEglerntGUym6h+3DM/k=",
                     SecondaryApiKey = "Q2xpZW50.5/fRn0AL2RYPHcrT73HCSIuIYm2Iew5+1v9nvtXrtE4="
+                }
+            };
+        }
+
+        public IEnumerable<UserRefreshToken> GetFakeUserRefreshTokens()
+        {
+            return new List<UserRefreshToken>
+            {
+                new UserRefreshToken
+                {
+                    Id = 1,
+                    PublicKey = Guid.Parse("8e483815-1f5a-4ae3-af15-b91cc9371878"),
+                    Token = "VXNlcg==.dx9lkJq6WfEA+8oNoikmI4Mk3N/CeGY5hptngJSBmILXp8klx2A1vlzcWpieYa5xiUqimrTYAUrNTI0eQr84gQ==",
+                    UserId = 1,
+                    Created = DateTime.UtcNow,
+                    Expires = DateTime.UtcNow.AddDays(1)
                 }
             };
         }

--- a/aiof.auth.data/ITokenRequest.cs
+++ b/aiof.auth.data/ITokenRequest.cs
@@ -24,8 +24,16 @@ namespace aiof.auth.data
 
     public interface IRevokeRequest
     {
-        int ClientId { get; set; }
         string Token { get; set; }
+    }
+    public interface IRevokeUserRequest : IRevokeRequest
+    {
+        int UserId { get; set; }
+    }
+
+    public interface IRevokeClientRequest : IRevokeRequest
+    {
+        int ClientId { get; set; }
     }
 
     public interface  IValidationRequest 

--- a/aiof.auth.data/ITokenResponse.cs
+++ b/aiof.auth.data/ITokenResponse.cs
@@ -36,13 +36,10 @@ namespace aiof.auth.data
     }
 
     /// <summary>
-    /// Response to revoke a Client refresh token
+    /// Response to revoke a refresh token
     /// </summary>
     public interface IRevokeResponse
     {
-        [Required]
-        int ClientId { get; set; }
-
         [JsonPropertyName("refresh_token")]
         [Required]
         [MaxLength(128)]

--- a/aiof.auth.data/IUser.cs
+++ b/aiof.auth.data/IUser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
@@ -50,6 +51,6 @@ namespace aiof.auth.data
         DateTime Created { get; set; }
 
         [JsonIgnore]
-        UserRefreshToken RefreshToken { get; set; }
+        ICollection<UserRefreshToken> RefreshTokens { get; set; }
     }
 }

--- a/aiof.auth.data/IUser.cs
+++ b/aiof.auth.data/IUser.cs
@@ -48,5 +48,8 @@ namespace aiof.auth.data
 
         [Required]
         DateTime Created { get; set; }
+
+        [JsonIgnore]
+        UserRefreshToken RefreshToken { get; set; }
     }
 }

--- a/aiof.auth.data/IUserRefreshToken.cs
+++ b/aiof.auth.data/IUserRefreshToken.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.auth.data
+{
+    public interface IUserRefreshToken
+    {
+        [JsonIgnore]
+        [Required]
+        int Id { get; set; }
+
+        [JsonIgnore]
+        [Required]
+        Guid PublicKey { get; set; }
+
+        [Required]
+        string Token { get; set; }
+
+        [Required]
+        int UserId { get; set; }
+
+        [Required]
+        DateTime Created { get; set; }
+
+        [Required]
+        DateTime Expires { get; set; }
+
+        DateTime? Revoked { get; set; }
+    }
+}

--- a/aiof.auth.data/IUserRefreshToken.cs
+++ b/aiof.auth.data/IUserRefreshToken.cs
@@ -19,6 +19,7 @@ namespace aiof.auth.data
         [Required]
         string Token { get; set; }
 
+        [JsonIgnore]
         [Required]
         int UserId { get; set; }
 

--- a/aiof.auth.data/TokenRequest.cs
+++ b/aiof.auth.data/TokenRequest.cs
@@ -52,17 +52,32 @@ namespace aiof.auth.data
     }
 
     /// <summary>
-    /// Request to revoke a Client refresh token
+    /// Request to revoke a refresh token
     /// </summary>
     public class RevokeRequest : IRevokeRequest
     {
-        [Required]
-        public int ClientId { get; set; }
-
         [JsonPropertyName("refresh_token")]
         [Required]
         [MaxLength(128)]
         public string Token { get; set; }
+    }
+
+    /// <summary>
+    /// Request to revoke a User refresh token
+    /// </summary>
+    public class RevokeUserRequest : RevokeRequest, IRevokeUserRequest
+    {
+        [Required]
+        public int UserId { get; set; }
+    }
+
+    /// <summary>
+    /// Request to revoke a Client refresh token
+    /// </summary>
+    public class RevokeClientRequest : RevokeRequest, IRevokeClientRequest
+    {
+        [Required]
+        public int ClientId { get; set; }
     }
 
     /// <summary>

--- a/aiof.auth.data/TokenResponse.cs
+++ b/aiof.auth.data/TokenResponse.cs
@@ -36,13 +36,10 @@ namespace aiof.auth.data
     }
 
     /// <summary>
-    /// Response to revoke a Client refresh token
+    /// Response to revoke a refresh token
     /// </summary>
     public class RevokeResponse : IRevokeResponse
     {
-        [Required]
-        public int ClientId { get; set; }
-
         [JsonPropertyName("refresh_token")]
         [Required]
         [MaxLength(128)]

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -49,6 +49,9 @@ namespace aiof.auth.data
 
         [Required]
         public DateTime Created { get; set; } = DateTime.UtcNow;
+
+        [JsonIgnore]
+        public UserRefreshToken RefreshToken { get; set; }
     }
 
     public class UserDto

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
@@ -51,7 +52,7 @@ namespace aiof.auth.data
         public DateTime Created { get; set; } = DateTime.UtcNow;
 
         [JsonIgnore]
-        public UserRefreshToken RefreshToken { get; set; }
+        public ICollection<UserRefreshToken> RefreshTokens { get; set; }
     }
 
     public class UserDto

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -52,7 +52,7 @@ namespace aiof.auth.data
         public DateTime Created { get; set; } = DateTime.UtcNow;
 
         [JsonIgnore]
-        public ICollection<UserRefreshToken> RefreshTokens { get; set; }
+        public ICollection<UserRefreshToken> RefreshTokens { get; set; } = new List<UserRefreshToken>();
     }
 
     public class UserDto

--- a/aiof.auth.data/UserRefreshToken.cs
+++ b/aiof.auth.data/UserRefreshToken.cs
@@ -20,6 +20,7 @@ namespace aiof.auth.data
         [Required]
         public string Token { get; set; } = Utils.GenerateApiKey<User>(64);
 
+        [JsonIgnore]
         [Required]
         public int UserId { get; set; }
 

--- a/aiof.auth.data/UserRefreshToken.cs
+++ b/aiof.auth.data/UserRefreshToken.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.auth.data
+{
+    class UserRefreshToken : 
+        IPublicKeyId
+    {
+        [JsonIgnore]
+        [Required]
+        public int Id { get; set; }
+
+        [JsonIgnore]
+        [Required]
+        public Guid PublicKey { get; set; } = Guid.NewGuid();
+
+        public string Token { get; set; } = Utils.GenerateApiKey<User>(64);
+        public int UserId { get; set; }
+        public DateTime Created { get; set; } = DateTime.UtcNow;
+        public DateTime Expires { get; set; }
+        public DateTime? Revoked { get; set; }
+    }
+}

--- a/aiof.auth.data/UserRefreshToken.cs
+++ b/aiof.auth.data/UserRefreshToken.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace aiof.auth.data
 {
-    class UserRefreshToken : 
+    public class UserRefreshToken : 
         IPublicKeyId
     {
         [JsonIgnore]
@@ -17,10 +17,18 @@ namespace aiof.auth.data
         [Required]
         public Guid PublicKey { get; set; } = Guid.NewGuid();
 
+        [Required]
         public string Token { get; set; } = Utils.GenerateApiKey<User>(64);
+
+        [Required]
         public int UserId { get; set; }
+
+        [Required]
         public DateTime Created { get; set; } = DateTime.UtcNow;
+
+        [Required]
         public DateTime Expires { get; set; }
+
         public DateTime? Revoked { get; set; }
     }
 }

--- a/aiof.auth.data/UserRefreshToken.cs
+++ b/aiof.auth.data/UserRefreshToken.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace aiof.auth.data
 {
-    public class UserRefreshToken : 
+    public class UserRefreshToken : IUserRefreshToken,
         IPublicKeyId
     {
         [JsonIgnore]

--- a/aiof.auth.data/Utils.cs
+++ b/aiof.auth.data/Utils.cs
@@ -29,7 +29,7 @@ namespace aiof.auth.data
             return client;
         }
 
-        public static string DecodeApiKey(
+        public static string DecodeKey(
             [NotNull] this string apiKey)
         {
             return apiKey.Split('.')

--- a/aiof.auth.data/Utils.cs
+++ b/aiof.auth.data/Utils.cs
@@ -61,21 +61,5 @@ namespace aiof.auth.data
         {
             return value.Replace(' ', '-').ToLower();
         }
-
-        public static T ParseEnum<T>(string value)
-        {
-            return (T)Enum.Parse(typeof(T), value, true);
-        }
-
-        public static T ToEnum<T>(
-            [NotNull] this string value)
-        {
-            return (T)Enum.Parse(typeof(T), value, true);
-        }
-        public static AlgType ToEnum(
-            [NotNull] this string value)
-        {
-            return (AlgType)Enum.Parse(typeof(AlgType), value, true);
-        }
     }
 }

--- a/aiof.auth.services/AuthRepository.cs
+++ b/aiof.auth.services/AuthRepository.cs
@@ -236,17 +236,33 @@ namespace aiof.auth.services
         }
 
         public async Task<IRevokeResponse> RevokeTokenAsync(
-            int clientId,
-            string token)
+            string token,
+            int? userId = null,
+            int? clientId = null)
         {
-            var clientRefresh = await _clientRepo.RevokeTokenAsync(clientId, token);
-
-            return new RevokeResponse
+            if (clientId != null)
             {
-                ClientId = clientRefresh.ClientId,
-                Token = clientRefresh.Token,
-                Revoked = clientRefresh.Revoked
-            };
+                var clientRefresh = await _clientRepo.RevokeTokenAsync((int)clientId, token);
+
+                return new RevokeResponse
+                {
+                    Token = clientRefresh.Token,
+                    Revoked = clientRefresh.Revoked
+                };
+            }
+            else if (userId != null)
+            {
+                var userRefresh = await _userRepo.RevokeTokenAsync((int)userId, token);
+
+                return new RevokeResponse
+                {
+                    Token = userRefresh.Token,
+                    Revoked = userRefresh.Revoked
+                };
+            }
+            else
+                throw new AuthFriendlyException(HttpStatusCode.BadRequest,
+                    $"Couldn't revoke Token='{token}' for UserId='{userId}' or ClientId='{clientId}'");
         }
 
         public JsonWebKey GetPublicJsonWebKey()

--- a/aiof.auth.services/AuthRepository.cs
+++ b/aiof.auth.services/AuthRepository.cs
@@ -68,17 +68,10 @@ namespace aiof.auth.services
                         $"Invalid token request");
             }
         }
-     
-        public ITokenResponse RefreshToken(IClient client)
-        {
-            return GenerateJwtToken(
-                client: client,
-                expiresIn: _envConfig.JwtRefreshExpires);
-        }
 
         public async Task<ITokenResponse> GenerateJwtTokenAsync(string apiKey)
         {
-            switch (apiKey.DecodeApiKey())
+            switch (apiKey.DecodeKey())
             {
                 case nameof(User):
                     var user = await _userRepo.GetUserAsync(apiKey);
@@ -97,16 +90,25 @@ namespace aiof.auth.services
             }
         }
 
+        public ITokenResponse RefreshToken(IClient client)
+        {
+            return GenerateJwtToken(
+                client: client,
+                expiresIn: _envConfig.JwtRefreshExpires);
+        }
+
         public ITokenUserResponse GenerateJwtToken(
             IUser user,
-            string refreshToken = null)
+            string refreshToken = null,
+            int? expiresIn = null)
         {
             var token = GenerateJwtToken<User>(new Claim[]
                 {
                     new Claim(AiofClaims.PublicKey, user.PublicKey.ToString())
                 },
                 entity: user as IPublicKeyId,
-                refreshToken: refreshToken);
+                refreshToken: refreshToken,
+                expiresIn: expiresIn);
 
             return new TokenUserResponse
             {

--- a/aiof.auth.services/ClientRepository.cs
+++ b/aiof.auth.services/ClientRepository.cs
@@ -23,8 +23,6 @@ namespace aiof.auth.services
         private readonly AuthContext _context;
         private readonly AbstractValidator<ClientDto> _clientDtoValidator;
 
-        private const int _refreshTokenValidDay = 1;
-
         public ClientRepository(
             ILogger<ClientRepository> logger,
             IMemoryCache cache,

--- a/aiof.auth.services/IAuthRepository.cs
+++ b/aiof.auth.services/IAuthRepository.cs
@@ -14,7 +14,8 @@ namespace aiof.auth.services
         Task<ITokenResponse> GetTokenAsync(ITokenRequest request);
         ITokenUserResponse GenerateJwtToken(
             IUser user,
-            string refreshToken = null);
+            string refreshToken = null,
+            int? expiresIn = null);
         ITokenResponse GenerateJwtToken(
             IClient client, 
             string refreshToken = null,

--- a/aiof.auth.services/IAuthRepository.cs
+++ b/aiof.auth.services/IAuthRepository.cs
@@ -27,10 +27,11 @@ namespace aiof.auth.services
             int? expiresIn = null)
             where T : class, IPublicKeyId;
         RsaSecurityKey GetRsaKey(RsaKeyType rsaKeyType);
-        ITokenResult ValidateToken(string token); 
+        ITokenResult ValidateToken(string token);
         Task<IRevokeResponse> RevokeTokenAsync(
-            int clientId, 
-            string token);
+            string token,
+            int? userId = null,
+            int? clientId = null);
         JsonWebKey GetPublicJsonWebKey();
         IOpenIdConfig GetOpenIdConfig(
              string host,

--- a/aiof.auth.services/IAuthRepository.cs
+++ b/aiof.auth.services/IAuthRepository.cs
@@ -12,7 +12,9 @@ namespace aiof.auth.services
     public interface IAuthRepository
     {
         Task<ITokenResponse> GetTokenAsync(ITokenRequest request);
-        ITokenUserResponse GenerateJwtToken(IUser user);
+        ITokenUserResponse GenerateJwtToken(
+            IUser user,
+            string refreshToken = null);
         ITokenResponse GenerateJwtToken(
             IClient client, 
             string refreshToken = null,

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -13,7 +13,9 @@ namespace aiof.auth.services
         Task<IUser> GetUserByUsernameAsync(
             string username, 
             bool asNoTracking = true);
-        Task<IUser> GetUserAsync(string username, string password);
+        Task<IUser> GetUserAsync(
+            string username, 
+            string password);
         Task<IUser> GetUserAsync(
             string firstName,
             string lastName,

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -23,6 +23,7 @@ namespace aiof.auth.services
             string email,
             string username);
         Task<IUser> GetUserAsync(UserDto userDto);
+        Task<IUser> GetUserByRefreshTokenAsync(string refreshToken);
         Task<IUserRefreshToken> GetRefreshTokenAsync(
             int userId,
             bool revoked = false);

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -29,6 +29,7 @@ namespace aiof.auth.services
         Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(
             int userId,
             bool revoked = false);
+        Task<IUserRefreshToken> GetOrAddRefreshTokenAsync(int userId);
         Task<bool> DoesUsernameExistAsync(string username);
         Task<IUser> AddUserAsync(UserDto userDto);
         Task<IUser> UpdatePasswordAsync(

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -24,12 +24,8 @@ namespace aiof.auth.services
             string username);
         Task<IUser> GetUserAsync(UserDto userDto);
         Task<IUser> GetUserByRefreshTokenAsync(string refreshToken);
-        Task<IUserRefreshToken> GetRefreshTokenAsync(
-            int userId,
-            bool revoked = false);
-        Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(
-            int userId,
-            bool revoked = false);
+        Task<IUserRefreshToken> GetRefreshTokenAsync(int userId);
+        Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(int userId);
         Task<IUserRefreshToken> GetOrAddRefreshTokenAsync(int userId);
         Task<bool> DoesUsernameExistAsync(string username);
         Task<IUser> AddUserAsync(UserDto userDto);

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -33,6 +33,9 @@ namespace aiof.auth.services
             string username, 
             string oldPassword, 
             string newPassword);
+        Task<IUserRefreshToken> RevokeTokenAsync(
+            int userId,
+            string token);
         string Hash(string password);
         bool Check(string hash, string password);
     }

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using aiof.auth.data;
@@ -22,6 +23,8 @@ namespace aiof.auth.services
             string email,
             string username);
         Task<IUser> GetUserAsync(UserDto userDto);
+        Task<IUserRefreshToken> GetRefreshTokenAsync(int userId);
+        Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(int userId);
         Task<bool> DoesUsernameExistAsync(string username);
         Task<IUser> AddUserAsync(UserDto userDto);
         Task<IUser> UpdatePasswordAsync(

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -23,8 +23,12 @@ namespace aiof.auth.services
             string email,
             string username);
         Task<IUser> GetUserAsync(UserDto userDto);
-        Task<IUserRefreshToken> GetRefreshTokenAsync(int userId);
-        Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(int userId);
+        Task<IUserRefreshToken> GetRefreshTokenAsync(
+            int userId,
+            bool revoked = false);
+        Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(
+            int userId,
+            bool revoked = false);
         Task<bool> DoesUsernameExistAsync(string username);
         Task<IUser> AddUserAsync(UserDto userDto);
         Task<IUser> UpdatePasswordAsync(

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Linq;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 
@@ -108,6 +109,21 @@ namespace aiof.auth.services
                 userDto.LastName,
                 userDto.Email,
                 userDto.Username);
+        }
+
+        public async Task<IUserRefreshToken> GetRefreshTokenAsync(int userId)
+        {
+            return (await GetRefreshTokensAsync(userId))
+                .First();
+        }
+        public async Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(int userId)
+        {
+            return await _context.UserRefreshTokens
+                .AsNoTracking()
+                .AsQueryable()
+                .Where(x => x.UserId == userId)
+                .OrderByDescending(x => x.Expires)
+                .ToListAsync();
         }
 
         public async Task<bool> DoesUsernameExistAsync(string username)

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -111,19 +111,26 @@ namespace aiof.auth.services
                 userDto.Username);
         }
 
-        public async Task<IUserRefreshToken> GetRefreshTokenAsync(int userId)
+        public async Task<IUserRefreshToken> GetRefreshTokenAsync(
+            int userId,
+            bool revoked = false)
         {
-            return (await GetRefreshTokensAsync(userId))
-                .First();
+            return (await GetRefreshTokensAsync(userId, revoked)).First();
         }
-        public async Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(int userId)
+        public async Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(
+            int userId,
+            bool revoked = false)
         {
-            return await _context.UserRefreshTokens
+            var refreshTokens = await _context.UserRefreshTokens
                 .AsNoTracking()
                 .AsQueryable()
                 .Where(x => x.UserId == userId)
                 .OrderByDescending(x => x.Expires)
                 .ToListAsync();
+
+            return revoked
+                ? refreshTokens.Where(x => x.Revoked != null)
+                : refreshTokens;
         }
 
         public async Task<bool> DoesUsernameExistAsync(string username)

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -46,12 +46,11 @@ namespace aiof.auth.services
         {
             return asNoTracking
                 ? _context.Users
-                    .Include(x => x.RefreshTokens
-                        .OrderByDescending(x => x.Expires)
-                        .Take(1))
+                    .Include(x => x.RefreshTokens)
                     .AsNoTracking()
                     .AsQueryable()
                 : _context.Users
+                    .Include(x => x.RefreshTokens)
                     .AsQueryable();
         }
 

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -173,7 +173,7 @@ namespace aiof.auth.services
                 $"{nameof(User.Email)}='{user.Email}' and " +
                 $"{nameof(User.Username)}='{user.Username}'");
 
-            await GetOrAddRefreshTokenAsync(user.Id);
+            await AddRefreshTokenAsync(user.Id);
 
             return user;
         }

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -117,28 +117,20 @@ namespace aiof.auth.services
                 .FirstOrDefaultAsync(x => x.RefreshTokens.Any(x => x.Token == refreshToken))
                 ?? throw new AuthNotFoundException($"{nameof(User)} with RefreshToken='{refreshToken}' was not found");
         }
-        public async Task<IUserRefreshToken> GetRefreshTokenAsync(
-            int userId,
-            bool revoked = false)
+        public async Task<IUserRefreshToken> GetRefreshTokenAsync(int userId)
         {
-            return (await GetRefreshTokensAsync(userId, revoked))
+            return (await GetRefreshTokensAsync(userId))
                 ?.Where(x => DateTime.UtcNow < x.Expires)
-                ?.First();
+                ?.FirstOrDefault();
         }
-        public async Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(
-            int userId,
-            bool revoked = false)
+        public async Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(int userId)
         {
-            var refreshTokens = await _context.UserRefreshTokens
+            return await _context.UserRefreshTokens
                 .AsNoTracking()
                 .AsQueryable()
-                .Where(x => x.UserId == userId)
+                .Where(x => x.UserId == userId && x.Revoked != null)
                 .OrderByDescending(x => x.Expires)
                 .ToListAsync();
-
-            return revoked
-                ? refreshTokens.Where(x => x.Revoked != null)
-                : refreshTokens;
         }
         public async Task<IUserRefreshToken> GetOrAddRefreshTokenAsync(int userId)
         {

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -128,7 +128,7 @@ namespace aiof.auth.services
             return await _context.UserRefreshTokens
                 .AsNoTracking()
                 .AsQueryable()
-                .Where(x => x.UserId == userId && x.Revoked != null)
+                .Where(x => x.UserId == userId && x.Revoked == null)
                 .OrderByDescending(x => x.Expires)
                 .ToListAsync();
         }

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -47,11 +47,9 @@ namespace aiof.auth.services
         {
             return asNoTracking
                 ? _context.Users
-                    .Include(x => x.RefreshTokens)
                     .AsNoTracking()
                     .AsQueryable()
                 : _context.Users
-                    .Include(x => x.RefreshTokens)
                     .AsQueryable();
         }
 
@@ -73,7 +71,7 @@ namespace aiof.auth.services
         {
             return await GetUsersQuery(asNoTracking)
                 .FirstOrDefaultAsync(x => x.Username == username)
-                ?? throw new AuthNotFoundException($"User with Username='{username}' was not found.");
+                ?? throw new AuthNotFoundException($"User with Username='{username}' was not found");
         }
         public async Task<IUser> GetUserAsync(
             string username, 
@@ -111,6 +109,14 @@ namespace aiof.auth.services
                 userDto.Username);
         }
 
+        public async Task<IUser> GetUserByRefreshTokenAsync(string refreshToken)
+        {
+            return await _context.Users
+                .Include(x => x.RefreshTokens)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.RefreshTokens.Any(x => x.Token == refreshToken))
+                ?? throw new AuthNotFoundException($"{nameof(User)} with RefreshToken='{refreshToken}' was not found");
+        }
         public async Task<IUserRefreshToken> GetRefreshTokenAsync(
             int userId,
             bool revoked = false)

--- a/aiof.auth.tests/AuthRepository.Tests.cs
+++ b/aiof.auth.tests/AuthRepository.Tests.cs
@@ -118,10 +118,9 @@ namespace aiof.auth.tests
             int clientId, 
             string token)
         {
-            var revokedTokenResp = await _repo.RevokeTokenAsync(clientId, token);
+            var revokedTokenResp = await _repo.RevokeTokenAsync(token, clientId: clientId);
 
             Assert.NotNull(revokedTokenResp);
-            Assert.Equal(clientId, revokedTokenResp.ClientId);
             Assert.Equal(token, revokedTokenResp.Token);
             Assert.NotNull(revokedTokenResp.Revoked);
         }

--- a/aiof.auth.tests/Helper.cs
+++ b/aiof.auth.tests/Helper.cs
@@ -151,6 +151,14 @@ namespace aiof.auth.tests
             );
         }
 
+        public static IEnumerable<object[]> UserRefreshTokensUserIdToken()
+        {
+            return _Fake.GetFakeUserRefreshTokensData(
+                userId: true,
+                refreshToken: true
+            );
+        }
+
         public static IEnumerable<object[]> ClientRefreshClientIdToken()
         {
             return _Fake.GetFakeClientRefreshTokensData(

--- a/aiof.auth.tests/Helper.cs
+++ b/aiof.auth.tests/Helper.cs
@@ -141,6 +141,13 @@ namespace aiof.auth.tests
             );
         }
 
+        public static IEnumerable<object[]> UserRefreshTokensUserId()
+        {
+            return _Fake.GetFakeUserRefreshTokensData(
+                userId: true
+            );
+        }
+
         public static IEnumerable<object[]> ClientRefreshClientIdToken()
         {
             return _Fake.GetFakeClientRefreshTokensData(

--- a/aiof.auth.tests/Helper.cs
+++ b/aiof.auth.tests/Helper.cs
@@ -31,12 +31,8 @@ namespace aiof.auth.tests
             { "Jwt:Type", "Bearer" },
             { "Jwt:Issuer", "aiof:auth" },
             { "Jwt:Audience", "aiof:auth:audience" },
-            { "Jwt:Secret", "egSavDYTnYi3M5gWe3g08XQ46S0E2fdh" },
             { "Jwt:PrivateKey", "<RSAKeyValue><Modulus>1EW6wdxMPYBCc/L9RZRSpZx02eSI4YerUl9kHpYk7yFDRArngEZm2ckhQgZFU5BH13JYkfiyB5vLx9L8qZf9w/DtAZewDCaRGWckhGeNtGBDJvCAJaI/PVkwVVOLV/rosbBaqeRjiE4AQl7H+QSPzeidXmf5Zh+otywvtcZqLw8wwPLPFyoqrTeF6naDqxwkGW4E33EwR1qSp2L7RjHJleVbp6EieSsOruekT4QHCVzOfL3C5rz8QmFCPDRycPwuCnB1z0rEm5LWZuDd1z2xFxr3WFgofyEJ+LPicAt/ULrCrj0PB8/f0tMNXGPzj/ZXyerZ3gACX1shLRTDGXxMYQ==</Modulus><Exponent>AQAB</Exponent><P>8UWMH6VUcR//t+hL5zGaQ+EZcGPELt1u+e3wnBCeU1w0yUVqej0Pd/EeK8aK7Ee8y6TrFtelZZJeJEi+WPZ4TCezuNOxS7gQv+Z+BJ82cppHT32r883r8Df+g9JSQMDokJXBmcOcqhZi7kQL94viJ/6HbUL69uIxbxsLN0Vsy8U=</P><Q>4Tr/jBVxOQqo2y6QPUqPYCZektKZExdcxSk9KZSeFD43WglGLJbqk5NrIW6EF7KkbrtroftHByAXjEOfmtVYmw1WCInX2iY0JQHJ/5zvzQl36ERZQPjQqxfWHoZ5pwRrIpREEqWTLIqkEDn2cWDnq5EjkmeqF1wWMQ4cU+gse+0=</Q><DP>m7BXNWyISt9tMg1yPWPiuf6dXcrjI6K8JAcIhoyqvfv4DBEBHpQcUTeEUpcxujqod3iaQwkwr5R9r0hJnDqfcfUEojXoaIYEOPDRTMY4akdn0MG1ngO5Ri+7yvCDJ0nUSMh6P3DcvVzoxfufBUR80XYLidP5Air/30RCPo5MIEk=</DP><DQ>RcPMnEuYAp82po3Jx/Jsbs/zw27QU4WNCtU3SMXsIUEUTCNLRUyJ5KRpLrXY3K5NGK+dK1N2MNLT+HKJ4Z/sDjsXRxXLcpsa08u2EiM+dDhWl+9z5hgsKpL7lAD7dax8sv1SCKSY7dcT8qLBn2Tw3cfbSOIrYYj4psFELQlhnhE=</DQ><InverseQ>Pe6uqbHvu++T28+afeliOsImw+HrMm2f+v8Hq+zIHWkXDlIoTlhT30uNg2DzhIJgRrC+wVm+ZafGqk86d2UldYV93uRRLjmVkAlbfB29WoB8fU9XSbU69FZzGLlkVyGGX5V1nJK0Bf41iiIg14AqsZbhTt1kZoitZhwcrMWcixQ=</InverseQ><D>mn+2EmuZQhocQ/BTz1TJYqihlAX2atAoLegoIur9Lt9y6g9Vt9OGAHWXs0qFIvEcmP8s3/G3Ajqu813pcDakCP1OQ554EB/x9B9SQNxuEx8NQUZCvyF8DdbgivonrX195/aHxqfomcjL/4Kk4eYkFKZ+A7yBlYbtcYTDpPYpSt3b/9wRrKmpr10D+GefZ7gw5uG7C6jqCUTTT16rDeAL1NDB5loCZJVrzGal1yfbdgg+IP4OI6XlF8dJXkYsH2OERsZeB335X6dfYdk2aN+DP4dDxtHReh//OwJiz4kFb/0vGfiF2xZ4Grp/B/TOxz0bcJoQ4tgMYBamDImX7iRpwQ==</D></RSAKeyValue>" },
             { "Jwt:PublicKey", "<RSAKeyValue><Modulus>1EW6wdxMPYBCc/L9RZRSpZx02eSI4YerUl9kHpYk7yFDRArngEZm2ckhQgZFU5BH13JYkfiyB5vLx9L8qZf9w/DtAZewDCaRGWckhGeNtGBDJvCAJaI/PVkwVVOLV/rosbBaqeRjiE4AQl7H+QSPzeidXmf5Zh+otywvtcZqLw8wwPLPFyoqrTeF6naDqxwkGW4E33EwR1qSp2L7RjHJleVbp6EieSsOruekT4QHCVzOfL3C5rz8QmFCPDRycPwuCnB1z0rEm5LWZuDd1z2xFxr3WFgofyEJ+LPicAt/ULrCrj0PB8/f0tMNXGPzj/ZXyerZ3gACX1shLRTDGXxMYQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue>" },
-            { "Jwt:Algorithm:Default", "RS256" },
-            { "Jwt:Algorithm:User", "HS256" },
-            { "Jwt:Algorithm:Client", "RS256" },
             { "Hash:Iterations", "10000" },
             { "Hash:SaltSize", "16" },
             { "Hash:KeySize", "32" }
@@ -145,6 +141,13 @@ namespace aiof.auth.tests
         {
             return _Fake.GetFakeUserRefreshTokensData(
                 userId: true
+            );
+        }
+
+        public static IEnumerable<object[]> UserRefreshTokensToken()
+        {
+            return _Fake.GetFakeUserRefreshTokensData(
+                refreshToken: true
             );
         }
 

--- a/aiof.auth.tests/UserRepository.Tests.cs
+++ b/aiof.auth.tests/UserRepository.Tests.cs
@@ -88,8 +88,6 @@ namespace aiof.auth.tests
             Assert.NotNull(user.Password);
             Assert.NotEqual(new DateTime(), user.Created);
         }
-
-
         [Theory]
         [MemberData(nameof(Helper.UserRefreshTokensUserId), MemberType = typeof(Helper))]
         public async Task GetRefreshTokenAsync_ByUserId_Valid(int userId)
@@ -98,6 +96,10 @@ namespace aiof.auth.tests
 
             Assert.NotNull(refreshToken);
             Assert.NotNull(refreshToken.Token);
+            Assert.Equal(userId, refreshToken.UserId);
+            Assert.NotEqual(new DateTime(), refreshToken.Created);
+            Assert.NotEqual(new DateTime(), refreshToken.Expires);
+            Assert.Null(refreshToken.Revoked);
         }
         [Theory]
         [MemberData(nameof(Helper.UserRefreshTokensUserId), MemberType = typeof(Helper))]
@@ -107,6 +109,19 @@ namespace aiof.auth.tests
 
             Assert.NotNull(refreshTokens);
             Assert.NotEmpty(refreshTokens);
+        }
+        [Theory]
+        [MemberData(nameof(Helper.UserRefreshTokensUserId), MemberType = typeof(Helper))]
+        public async Task GetOrAddRefreshTokenAsync_NotRevoked(int userId)
+        {
+            var refreshToken = await _repo.GetOrAddRefreshTokenAsync(userId);
+
+            Assert.NotNull(refreshToken);
+            Assert.NotNull(refreshToken.Token);
+            Assert.Equal(userId, refreshToken.UserId);
+            Assert.NotEqual(new DateTime(), refreshToken.Created);
+            Assert.NotEqual(new DateTime(), refreshToken.Expires);
+            Assert.Null(refreshToken.Revoked);
         }
 
         [Theory]

--- a/aiof.auth.tests/UserRepository.Tests.cs
+++ b/aiof.auth.tests/UserRepository.Tests.cs
@@ -75,6 +75,25 @@ namespace aiof.auth.tests
         }
 
         [Theory]
+        [MemberData(nameof(Helper.UserRefreshTokensUserId), MemberType = typeof(Helper))]
+        public async Task GetRefreshTokenAsync_ByUserId_Valid(int userId)
+        {
+            var refreshToken = await _repo.GetRefreshTokenAsync(userId);
+
+            Assert.NotNull(refreshToken);
+            Assert.NotNull(refreshToken.Token);
+        }
+        [Theory]
+        [MemberData(nameof(Helper.UserRefreshTokensUserId), MemberType = typeof(Helper))]
+        public async Task GetRefreshTokensAsync_Valid(int userId)
+        {
+            var refreshTokens = await _repo.GetRefreshTokensAsync(userId);
+
+            Assert.NotNull(refreshTokens);
+            Assert.NotEmpty(refreshTokens);
+        }
+
+        [Theory]
         [MemberData(nameof(Helper.RandomUserDtos), MemberType = typeof(Helper))]
         public async Task AddUserAsync_Valid(
             string firstName,

--- a/aiof.auth.tests/UserRepository.Tests.cs
+++ b/aiof.auth.tests/UserRepository.Tests.cs
@@ -75,6 +75,22 @@ namespace aiof.auth.tests
         }
 
         [Theory]
+        [MemberData(nameof(Helper.UserRefreshTokensToken), MemberType = typeof(Helper))]
+        public async Task GetUserAsync_ByRefreshToken_Valid(string refreshToken)
+        {
+            var user = await _repo.GetUserByRefreshTokenAsync(refreshToken);
+
+            Assert.NotNull(user);
+            Assert.NotNull(user.FirstName);
+            Assert.NotNull(user.LastName);
+            Assert.NotNull(user.Email);
+            Assert.NotNull(user.Username);
+            Assert.NotNull(user.Password);
+            Assert.NotEqual(new DateTime(), user.Created);
+        }
+
+
+        [Theory]
         [MemberData(nameof(Helper.UserRefreshTokensUserId), MemberType = typeof(Helper))]
         public async Task GetRefreshTokenAsync_ByUserId_Valid(int userId)
         {

--- a/aiof.auth.tests/UserRepository.Tests.cs
+++ b/aiof.auth.tests/UserRepository.Tests.cs
@@ -123,6 +123,15 @@ namespace aiof.auth.tests
             Assert.NotEqual(new DateTime(), refreshToken.Expires);
             Assert.Null(refreshToken.Revoked);
         }
+        [Theory]
+        [MemberData(nameof(Helper.UserRefreshTokensUserIdToken), MemberType = typeof(Helper))]
+        public async Task RevokeTokenAsync(int userId, string token)
+        {
+            var revokedToken = await _repo.RevokeTokenAsync(userId, token);
+
+            Assert.NotNull(revokedToken);
+            Assert.NotNull(revokedToken.Revoked);
+        }
 
         [Theory]
         [MemberData(nameof(Helper.RandomUserDtos), MemberType = typeof(Helper))]

--- a/aiof.auth.tests/Utils.Tests.cs
+++ b/aiof.auth.tests/Utils.Tests.cs
@@ -67,8 +67,8 @@ namespace aiof.auth.tests
         [MemberData(nameof(Helper.UsersApiKeys), MemberType = typeof(Helper))]
         public void DecodeApiKey_Users_ApiKey_Valid(string primaryApiKey, string secondaryApiKey)
         {
-            var user1 = primaryApiKey.DecodeApiKey();
-            var user2 = secondaryApiKey.DecodeApiKey();
+            var user1 = primaryApiKey.DecodeKey();
+            var user2 = secondaryApiKey.DecodeKey();
 
             Assert.Equal(nameof(User), user1);
             Assert.Equal(nameof(User), user2);


### PR DESCRIPTION
Added user refresh token support and functionality. There is now logic to store and support User's refresh tokens. These tokens can be used to generate a new long-lived (24 hours) JWT

- Added `user_refresh_token`
- Added functionality to get User refresh token by `UserId`, `UserId` and `Token`, etc.
- Added functionality to revoke a User refresh token
- Added endpoint to revoke token
- Added unit tests