### PR TITLE
Add roles

### DIFF
--- a/aiof.auth.core/AuthUnauthorizedMiddleware.cs
+++ b/aiof.auth.core/AuthUnauthorizedMiddleware.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+using aiof.auth.data;
+
+namespace aiof.auth.core
+{
+    public class AuthUnauthorizedMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        private const string _defaultUnauthorizedMessage = "Unauthorized";
+        private const string _defaultForbiddenMessage = "Forbidden";
+
+        public AuthUnauthorizedMiddleware(
+            RequestDelegate next)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+        }
+
+        public async Task InvokeAsync(HttpContext httpContext)
+        {
+            await _next(httpContext);
+            await WriteUnauthorizedResponseAsync(httpContext);
+        }
+
+        public async Task WriteUnauthorizedResponseAsync(
+            HttpContext httpContext)
+        {
+            var statusCode = httpContext.Response.StatusCode;
+            var authProblem = new AuthProblemDetail();
+
+            if (statusCode == StatusCodes.Status403Forbidden)
+            {
+                authProblem.Code = StatusCodes.Status403Forbidden;
+                authProblem.Message = _defaultForbiddenMessage;
+            }
+
+            var authProblemJson = JsonSerializer.Serialize(authProblem);
+            httpContext.Response.ContentType = "application/problem+json";
+            
+            await httpContext.Response
+                .WriteAsync(authProblemJson);
+        }
+    }
+
+    public static partial class HttpStatusCodeExceptionMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseAuthUnauthorizedMiddleware(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<AuthUnauthorizedMiddleware>();
+        }
+    }
+}

--- a/aiof.auth.core/AuthUnauthorizedMiddleware.cs
+++ b/aiof.auth.core/AuthUnauthorizedMiddleware.cs
@@ -42,7 +42,7 @@ namespace aiof.auth.core
                 return;
 
             var statusCode = httpContext.Response.StatusCode;
-            var authProblem = new AuthProblemDetail();
+            var authProblem = new AuthProblemDetailBase();
 
             switch (statusCode)
             {
@@ -55,10 +55,6 @@ namespace aiof.auth.core
                     authProblem.Message = _defaultForbiddenMessage;
                     break;
             }
- 
-            authProblem.TraceId = string.IsNullOrEmpty(httpContext?.TraceIdentifier)
-                ? Guid.NewGuid().ToString()
-                : httpContext.TraceIdentifier;
 
             var authProblemJson = JsonSerializer
                 .Serialize(authProblem, new JsonSerializerOptions { IgnoreNullValues = true });

--- a/aiof.auth.core/Controllers/AuthController.cs
+++ b/aiof.auth.core/Controllers/AuthController.cs
@@ -53,7 +53,7 @@ namespace aiof.auth.core.Controllers
         [HttpPost]
         [Route("token/validate")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(ITokenResult), StatusCodes.Status200OK)]
         public IActionResult ValidateToken([FromBody, Required] ValidationRequest req)
         {
@@ -83,9 +83,9 @@ namespace aiof.auth.core.Controllers
         [Route("token/client/revoke")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> RevokeClientRefreshTokenAsync([FromBody, Required] RevokeClientRequest request)
         {
             return Ok(await _repo.RevokeTokenAsync(request.Token, clientId: request.ClientId));
@@ -99,9 +99,9 @@ namespace aiof.auth.core.Controllers
         [Route("token/user/revoke")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> RevokeUserRefreshTokenAsync([FromBody, Required] RevokeUserRequest request)
         {
             return Ok(await _repo.RevokeTokenAsync(request.Token, userId: request.UserId));

--- a/aiof.auth.core/Controllers/AuthController.cs
+++ b/aiof.auth.core/Controllers/AuthController.cs
@@ -78,13 +78,14 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Revoke an existing Client refresh token
         /// </summary>
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpPut]
         [Route("token/client/revoke")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> RevokeClientRefreshTokenAsync([FromBody, Required] RevokeClientRequest request)
         {
             return Ok(await _repo.RevokeTokenAsync(request.Token, clientId: request.ClientId));
@@ -93,13 +94,14 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Revoke an existing User refresh token
         /// </summary>
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpPut]
         [Route("token/user/revoke")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> RevokeUserRefreshTokenAsync([FromBody, Required] RevokeUserRequest request)
         {
             return Ok(await _repo.RevokeTokenAsync(request.Token, userId: request.UserId));

--- a/aiof.auth.core/Controllers/ClientController.cs
+++ b/aiof.auth.core/Controllers/ClientController.cs
@@ -40,9 +40,9 @@ namespace aiof.auth.core.Controllers
         [Route("{id}")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IClient), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetClientAsync([FromRoute, Required] int id)
+        public async Task<IActionResult> GetAsync([FromRoute, Required] int id)
         {
-            return Ok(await _repo.GetClientAsync(id));
+            return Ok(await _repo.GetAsync(id));
         }
 
         /// <summary>

--- a/aiof.auth.core/Controllers/ClientController.cs
+++ b/aiof.auth.core/Controllers/ClientController.cs
@@ -22,8 +22,8 @@ namespace aiof.auth.core.Controllers
     [Produces(Keys.ApplicationJson)]
     [Consumes(Keys.ApplicationJson)]
     [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status500InternalServerError)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
     public class ClientController : ControllerBase
     {
         private readonly IClientRepository _repo;

--- a/aiof.auth.core/Controllers/ClientController.cs
+++ b/aiof.auth.core/Controllers/ClientController.cs
@@ -16,13 +16,14 @@ namespace aiof.auth.core.Controllers
     /// <summary>
     /// Everything aiof client
     /// </summary>
-    [Authorize]
+    [Authorize(Roles = Roles.Admin)]
     [ApiController]
     [Route("client")]
     [Produces(Keys.ApplicationJson)]
     [Consumes(Keys.ApplicationJson)]
     [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public class ClientController : ControllerBase
     {
         private readonly IClientRepository _repo;

--- a/aiof.auth.core/Controllers/UserController.cs
+++ b/aiof.auth.core/Controllers/UserController.cs
@@ -89,7 +89,7 @@ namespace aiof.auth.core.Controllers
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IUserRefreshToken), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetUserRefreshTokenAsync([FromRoute, Required] int id)
         {
             return Ok(await _repo.GetRefreshTokenAsync(id));
@@ -103,7 +103,7 @@ namespace aiof.auth.core.Controllers
         [Route("{id}/refresh/tokens")]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<IUserRefreshToken>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetUserRefreshTokensAsync([FromRoute, Required] int id)
         {
             return Ok(await _repo.GetRefreshTokensAsync(id));
@@ -115,7 +115,7 @@ namespace aiof.auth.core.Controllers
         [AllowAnonymous]
         [HttpPost]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(IUser), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ITokenUserResponse), StatusCodes.Status201Created)]
         public async Task<IActionResult> AddUserAsync([FromBody, Required] UserDto userDto)
         {
             return Created(nameof(User), _authRepo.GenerateJwtToken(await _repo.AddUserAsync(userDto)));

--- a/aiof.auth.core/Controllers/UserController.cs
+++ b/aiof.auth.core/Controllers/UserController.cs
@@ -41,9 +41,9 @@ namespace aiof.auth.core.Controllers
         [HttpGet]
         [Route("{id}")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IUser), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserAsync([FromRoute, Required] int id)
         {
             return Ok(await _repo.GetUserAsync(id));
@@ -55,9 +55,9 @@ namespace aiof.auth.core.Controllers
         [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IUser), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserByUsernameAsync([FromQuery, Required] string username)
         {
             return Ok(await _repo.GetUserByUsernameAsync(username));
@@ -70,9 +70,9 @@ namespace aiof.auth.core.Controllers
         [HttpGet]
         [Route("{username}/{password}")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IUser), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserUsernamePasswordAsync(
             [FromRoute, Required] string username,
             [FromRoute, Required] string password)
@@ -87,9 +87,9 @@ namespace aiof.auth.core.Controllers
         [HttpGet]
         [Route("{id}/refresh/token")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserRefreshTokenAsync([FromRoute, Required] int id)
         {
             return Ok(await _repo.GetRefreshTokenAsync(id));
@@ -101,9 +101,9 @@ namespace aiof.auth.core.Controllers
         [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [Route("{id}/refresh/tokens")]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserRefreshTokensAsync([FromRoute, Required] int id)
         {
             return Ok(await _repo.GetRefreshTokensAsync(id));
@@ -127,9 +127,9 @@ namespace aiof.auth.core.Controllers
         [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [Route("hash/{password}")]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public IActionResult HashPassword([FromRoute, Required] string password)
         {
             return Ok(_repo.Hash(password));

--- a/aiof.auth.core/Controllers/UserController.cs
+++ b/aiof.auth.core/Controllers/UserController.cs
@@ -52,11 +52,12 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Get an existing User by Username
         /// </summary>
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IUser), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserByUsernameAsync([FromQuery, Required] string username)
         {
             return Ok(await _repo.GetUserByUsernameAsync(username));
@@ -65,12 +66,13 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Get an existing User by Username and Password
         /// </summary>
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [Route("{username}/{password}")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IUser), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserUsernamePasswordAsync(
             [FromRoute, Required] string username,
             [FromRoute, Required] string password)
@@ -81,12 +83,13 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Get a User first non-revoked refresh token
         /// </summary>
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [Route("{id}/refresh/token")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserRefreshTokenAsync([FromRoute, Required] int id)
         {
             return Ok(await _repo.GetRefreshTokenAsync(id));
@@ -95,11 +98,12 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Get a User refresh tokens
         /// </summary>
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [Route("{id}/refresh/tokens")]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserRefreshTokensAsync([FromRoute, Required] int id)
         {
             return Ok(await _repo.GetRefreshTokensAsync(id));
@@ -120,11 +124,12 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Hash a Password
         /// </summary>
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [Route("hash/{password}")]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public IActionResult HashPassword([FromRoute, Required] string password)
         {
             return Ok(_repo.Hash(password));

--- a/aiof.auth.core/Controllers/UserController.cs
+++ b/aiof.auth.core/Controllers/UserController.cs
@@ -37,12 +37,13 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Get an existing User by Id
         /// </summary>
-        [Authorize]
+        [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [Route("{id}")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IUser), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetUserAsync([FromRoute, Required] int id)
         {
             return Ok(await _repo.GetUserAsync(id));

--- a/aiof.auth.core/Startup.cs
+++ b/aiof.auth.core/Startup.cs
@@ -42,6 +42,7 @@ namespace aiof.auth.core
             services.AddScoped<IUserRepository, UserRepository>();
             services.AddScoped<IClientRepository, ClientRepository>();
             services.AddScoped<IAuthRepository, AuthRepository>();
+            services.AddScoped<IUtilRepository, UtilRepository>();
             services.AddScoped<FakeDataManager>();
             services.AddScoped<AbstractValidator<UserDto>, UserDtoValidator>();
             services.AddScoped<AbstractValidator<User>, UserValidator>();

--- a/aiof.auth.core/Startup.cs
+++ b/aiof.auth.core/Startup.cs
@@ -124,6 +124,7 @@ namespace aiof.auth.core
             }
 
             app.UseAuthExceptionMiddleware();
+            app.UseAuthUnauthorizedMiddleware();
             app.UseHealthChecks("/health");
             app.UseSwagger();
 

--- a/aiof.auth.data/AiofClaim.cs
+++ b/aiof.auth.data/AiofClaim.cs
@@ -27,6 +27,7 @@ namespace aiof.auth.data
         public const string Sig = "sig";
 
         public const string PublicKey = "public_key";
+        public const string Role = "role";
         public const string GivenName = "given_name";
         public const string FamilyName = "family_name";
         public const string Name = "name";
@@ -39,6 +40,7 @@ namespace aiof.auth.data
                 Sub,
                 Iss,
                 PublicKey,
+                Role,
                 GivenName,
                 FamilyName,
                 Name,

--- a/aiof.auth.data/AuthContext.cs
+++ b/aiof.auth.data/AuthContext.cs
@@ -10,6 +10,7 @@ namespace aiof.auth.data
         public virtual DbSet<Client> Clients { get; set; }
         public virtual DbSet<UserRefreshToken> UserRefreshTokens { get; set; }
         public virtual DbSet<ClientRefreshToken> ClientRefreshTokens { get; set; }
+        public virtual DbSet<Role> Roles { get; set; }
         public virtual DbSet<AiofClaim> Claims { get; set; }
 
         public AuthContext(DbContextOptions<AuthContext> options)
@@ -94,6 +95,17 @@ namespace aiof.auth.data
                     .HasForeignKey(x => x.ClientId)
                     .IsRequired()
                     .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            modelBuilder.Entity<Role>(e =>
+            {
+                e.ToTable("role");
+
+                e.HasKey(x => x.Id);
+
+                e.Property(x => x.Id).HasSnakeCaseColumnName().ValueGeneratedOnAdd().IsRequired();
+                e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.Name).HasSnakeCaseColumnName().HasMaxLength(50).IsRequired();
             });
 
             modelBuilder.Entity<AiofClaim>(e =>

--- a/aiof.auth.data/AuthContext.cs
+++ b/aiof.auth.data/AuthContext.cs
@@ -65,6 +65,12 @@ namespace aiof.auth.data
                 e.Property(x => x.PrimaryApiKey).HasSnakeCaseColumnName().HasMaxLength(100);
                 e.Property(x => x.SecondaryApiKey).HasSnakeCaseColumnName().HasMaxLength(100);
                 e.Property(x => x.Created).HasColumnType("timestamp").HasSnakeCaseColumnName().IsRequired();
+
+                e.HasOne(x => x.Role)
+                    .WithMany()
+                    .HasForeignKey(x => x.RoleId)
+                    .IsRequired()
+                    .OnDelete(DeleteBehavior.SetNull);
             });
 
             modelBuilder.Entity<UserRefreshToken>(e =>

--- a/aiof.auth.data/AuthContext.cs
+++ b/aiof.auth.data/AuthContext.cs
@@ -103,6 +103,9 @@ namespace aiof.auth.data
 
                 e.HasKey(x => x.Id);
 
+                e.HasIndex(x => x.Name)
+                    .IsUnique();
+
                 e.Property(x => x.Id).HasSnakeCaseColumnName().ValueGeneratedOnAdd().IsRequired();
                 e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();
                 e.Property(x => x.Name).HasSnakeCaseColumnName().HasMaxLength(50).IsRequired();

--- a/aiof.auth.data/AuthContext.cs
+++ b/aiof.auth.data/AuthContext.cs
@@ -42,7 +42,13 @@ namespace aiof.auth.data
                 e.HasMany(x => x.RefreshTokens)
                     .WithOne()
                     .HasForeignKey(x => x.UserId)
-                    .OnDelete(DeleteBehavior.Cascade);
+                    .OnDelete(DeleteBehavior.SetNull);
+
+                e.HasOne(x => x.Role)
+                    .WithMany()
+                    .HasForeignKey(x => x.RoleId)
+                    .IsRequired()
+                    .OnDelete(DeleteBehavior.SetNull);
             });
 
             modelBuilder.Entity<Client>(e =>

--- a/aiof.auth.data/AuthProblemDetail.cs
+++ b/aiof.auth.data/AuthProblemDetail.cs
@@ -22,4 +22,15 @@ namespace aiof.auth.data
         [JsonPropertyName("errors")]
         public IEnumerable<string> Errors { get; set; }
     }
+
+    public class AuthProblemDetailBase : IAuthProblemDetailBase
+    {
+        [JsonPropertyName("code")]
+        [Required]
+        public int? Code { get; set; }
+        
+        [JsonPropertyName("message")]
+        [Required]
+        public string Message { get; set; }
+    }
 }

--- a/aiof.auth.data/AutoMappingProfile.cs
+++ b/aiof.auth.data/AutoMappingProfile.cs
@@ -15,7 +15,8 @@ namespace aiof.auth.data
                 .ForMember(x => x.LastName, o => o.Condition(s => s.LastName != null))
                 .ForMember(x => x.Email, o => o.Condition(s => s.Email != null))
                 .ForMember(x => x.Username, o => o.Condition(s => s.Username != null))
-                .ForMember(x => x.Password, o => o.Condition(s => s.Password != null));
+                .ForMember(x => x.Password, o => o.Condition(s => s.Password != null))
+                .ForMember(x => x.RoleId, o => o.Condition(s => s.RoleId != null));
 
             CreateMap<TokenResponse, TokenUserResponse>()
                 .ForMember(x => x.TokenType, o => o.MapFrom(s => s.TokenType))

--- a/aiof.auth.data/Client.cs
+++ b/aiof.auth.data/Client.cs
@@ -52,5 +52,7 @@ namespace aiof.auth.data
         public string Name { get; set; }
 
         public bool Enabled { get; set; } = true;
+
+        public int? RoleId { get; set; }
     }
 }

--- a/aiof.auth.data/Client.cs
+++ b/aiof.auth.data/Client.cs
@@ -7,13 +7,41 @@ namespace aiof.auth.data
     public class Client : IClient,
         IPublicKeyId, IApiKey, IEnable
     {
-        [JsonIgnore] public int Id { get; set; }
-        [JsonIgnore] public Guid PublicKey { get; set; } = Guid.NewGuid();
+        [JsonIgnore]
+        [Required]
+        public int Id { get; set; }
+
+        [JsonIgnore]
+        [Required]
+        public Guid PublicKey { get; set; } = Guid.NewGuid();
+
+        [Required]
+        [MaxLength(200)]
         public string Name { get; set; }
+
+        [Required]
+        [MaxLength(50)]
         public string Slug { get; set; }
-        public bool Enabled { get; set; } = true;
+
+        [Required]
+        public bool Enabled { get; set; }
+
+        [Required]
+        [MaxLength(100)]
         public string PrimaryApiKey { get; set; }
+
+        [Required]
+        [MaxLength(100)]
         public string SecondaryApiKey { get; set; }
+        
+        [JsonIgnore]
+        [Required]
+        public int RoleId { get; set; }
+        
+        [Required]
+        public Role Role { get; set; }
+
+        [Required]
         public DateTime Created { get; set; } = DateTime.UtcNow;
     }
 

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -90,7 +90,8 @@ namespace aiof.auth.data
                     Slug = "gk-client-1",
                     Enabled = true,
                     PrimaryApiKey = "Q2xpZW50.YJj7MeyO1P9DpglkO8bFeAe6vYEBrFhpC9O6BrYR43w=",
-                    SecondaryApiKey = "Q2xpZW50.k3HO3GHyDpO0InUUWzzOUrs52Mt6tEdkq7MuTokH0M8="
+                    SecondaryApiKey = "Q2xpZW50.k3HO3GHyDpO0InUUWzzOUrs52Mt6tEdkq7MuTokH0M8=",
+                    RoleId = 3
                 },
                 new Client
                 {
@@ -100,7 +101,8 @@ namespace aiof.auth.data
                     Slug = "gk-client-2",
                     Enabled = true,
                     PrimaryApiKey = "Q2xpZW50.Jo9C+6F3no9pwg8s1OWDkUGs+wHAVbsWkcRTS0s/SjU=",
-                    SecondaryApiKey = "Q2xpZW50.FAe44G9HIrbDFCGa/ZF4xZE+m3Fne7cB7eNJuy2vcoc="
+                    SecondaryApiKey = "Q2xpZW50.FAe44G9HIrbDFCGa/ZF4xZE+m3Fne7cB7eNJuy2vcoc=",
+                    RoleId = 3
                 },
                 new Client
                 {
@@ -110,7 +112,8 @@ namespace aiof.auth.data
                     Slug = "gk-client-3",
                     Enabled = false,
                     PrimaryApiKey = "Q2xpZW50.Dpkt/TSLB+nlVyQwi/pSUhkwEglerntGUym6h+3DM/k=",
-                    SecondaryApiKey = "Q2xpZW50.5/fRn0AL2RYPHcrT73HCSIuIYm2Iew5+1v9nvtXrtE4="
+                    SecondaryApiKey = "Q2xpZW50.5/fRn0AL2RYPHcrT73HCSIuIYm2Iew5+1v9nvtXrtE4=",
+                    RoleId = 3
                 }
             };
         }

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -158,7 +158,7 @@ namespace aiof.auth.data
                     Token = "Q2xpZW50.VOJ6KaAss0+uQHD3e+OieAO2FrY2LsY/jzX6nAsSkdWqY7TGDI+b6lSsoNzvaMOwgu0TvXNPsQ7OlBBkuBYE0g==",
                     ClientId = 1,
                     Created = DateTime.UtcNow,
-                    Expires = DateTime.UtcNow.AddDays(1)
+                    Expires = DateTime.UtcNow.AddDays(7)
                 },
                 new ClientRefreshToken
                 {
@@ -166,9 +166,9 @@ namespace aiof.auth.data
                     PublicKey = Guid.Parse("c8f80b28-3459-42b8-9c13-30e719a14df7"),
                     Token = "Q2xpZW50.9hMijUAPRBnEohxLg3z9VZRSefhuBfZs9NgkR3Bf9/r1WG1mupPNCJcdmgGWLBob7fRMCH4JFBJPiahYfQXYdA==",
                     ClientId = 2,
-                    Created = DateTime.UtcNow.AddDays(-2),
+                    Created = DateTime.UtcNow.AddDays(-8),
                     Expires = DateTime.UtcNow.AddDays(-1),
-                    Revoked = DateTime.UtcNow.AddDays(-1)
+                    Revoked = DateTime.UtcNow.AddDays(-2)
                 }
             };
         }

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -48,7 +48,8 @@ namespace aiof.auth.data
                     LastName = "Kamacharov",
                     Email = "gkama@test.com",
                     Username = "gkama",
-                    Password = "10000.JiFzc3Ijb5vBrCb8COiNzA==.BzdHomm3RMu0sMHaBfTpY0B2WtbjFqi9tN7T//N+khA=" //pass1234
+                    Password = "10000.JiFzc3Ijb5vBrCb8COiNzA==.BzdHomm3RMu0sMHaBfTpY0B2WtbjFqi9tN7T//N+khA=", //pass1234
+                    RoleId = 1
                 },
                 new User
                 {
@@ -58,7 +59,8 @@ namespace aiof.auth.data
                     LastName = "Brown",
                     Email = "jessie@test.com",
                     Username = "jbro",
-                    Password = "10000.nBfnY+XzDhvP7Z2RcTLTtA==.rj6rCGGLRz5bvTxZj+cB8X+GbYf1nTu0x9iW2v3wEYc=" //password123
+                    Password = "10000.nBfnY+XzDhvP7Z2RcTLTtA==.rj6rCGGLRz5bvTxZj+cB8X+GbYf1nTu0x9iW2v3wEYc=", //password123
+                    RoleId = 2,
                 },
                 new User
                 {
@@ -70,7 +72,8 @@ namespace aiof.auth.data
                     Username = "gbest",
                     Password = "10000.JiFzc3Ijb5vBrCb8COiNzA==.BzdHomm3RMu0sMHaBfTpY0B2WtbjFqi9tN7T//N+khA=", //pass1234
                     PrimaryApiKey = "VXNlcg==.x0sHnNHFytELB6FkLb/L6Q/YXPoXAZ4bAHvztgr6vIU=",
-                    SecondaryApiKey = "VXNlcg==.VmNKkE4o6zxCq8Ut1BzkSU2R7RcCqo8y/jTklcTU6m8="
+                    SecondaryApiKey = "VXNlcg==.VmNKkE4o6zxCq8Ut1BzkSU2R7RcCqo8y/jTklcTU6m8=",
+                    RoleId = 2,
                 }
             };
         }

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -200,6 +200,12 @@ namespace aiof.auth.data
                     Id = 3,
                     PublicKey = Guid.Parse("d4d4a9a7-6dd2-4bfc-934a-9f94d8f8f82f"),
                     Name = Roles.Client
+                },
+                new Role
+                {
+                    Id = 4,
+                    PublicKey = Guid.Parse("f5a44fee-3789-478a-a1a3-2e5b7a87167c"),
+                    Name = Roles.Basic
                 }
             };
         }

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -30,6 +30,9 @@ namespace aiof.auth.data
             _context.Claims
                 .AddRange(GetFakeClaims());
 
+            _context.Roles
+                .AddRange(GetFakeRoles());
+
             _context.SaveChanges();
         }
 
@@ -166,6 +169,31 @@ namespace aiof.auth.data
                     Created = DateTime.UtcNow.AddDays(-2),
                     Expires = DateTime.UtcNow.AddDays(-1),
                     Revoked = DateTime.UtcNow.AddDays(-1)
+                }
+            };
+        }
+
+        public IEnumerable<Role> GetFakeRoles()
+        {
+            return new List<Role>
+            {
+                new Role
+                {
+                    Id = 1,
+                    PublicKey = Guid.Parse("596b81af-e6f1-4634-aa96-6ccc38bd0dc3"),
+                    Name = Roles.Admin
+                },
+                new Role
+                {
+                    Id = 2,
+                    PublicKey = Guid.Parse("8e5a2f46-1f7c-4e42-8f24-567e18c58b9c"),
+                    Name = Roles.User
+                },
+                new Role
+                {
+                    Id = 3,
+                    PublicKey = Guid.Parse("d4d4a9a7-6dd2-4bfc-934a-9f94d8f8f82f"),
+                    Name = Roles.Client
                 }
             };
         }

--- a/aiof.auth.data/IAuthProblemDetail.cs
+++ b/aiof.auth.data/IAuthProblemDetail.cs
@@ -22,4 +22,15 @@ namespace aiof.auth.data
         [JsonPropertyName("errors")]
         IEnumerable<string> Errors { get; set; }
     }
+
+    public interface IAuthProblemDetailBase
+    {
+        [JsonPropertyName("code")]
+        [Required]
+        int? Code { get; set; }
+        
+        [JsonPropertyName("message")]
+        [Required]
+        string Message { get; set; }
+    }
 }

--- a/aiof.auth.data/IClient.cs
+++ b/aiof.auth.data/IClient.cs
@@ -33,6 +33,13 @@ namespace aiof.auth.data
         [MaxLength(100)]
         string SecondaryApiKey { get; set; }
 
+        [JsonIgnore]
+        [Required]
+        int RoleId { get; set; }
+        
+        [Required]
+        Role Role { get; set; }
+
         [Required]
         DateTime Created { get; set; }
     }

--- a/aiof.auth.data/IRole.cs
+++ b/aiof.auth.data/IRole.cs
@@ -1,13 +1,16 @@
 using System;
+using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
 namespace aiof.auth.data
 {
     public interface IRole
     {
+        [JsonIgnore]
         [Required]
         int Id { get; set; }
 
+        [JsonIgnore]
         [Required]
         Guid PublicKey { get; set; }
 

--- a/aiof.auth.data/IRole.cs
+++ b/aiof.auth.data/IRole.cs
@@ -1,0 +1,18 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.auth.data
+{
+    public interface IRole
+    {
+        [Required]
+        int Id { get; set; }
+
+        [Required]
+        Guid PublicKey { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        string Name { get; set; }
+    }
+}

--- a/aiof.auth.data/IUser.cs
+++ b/aiof.auth.data/IUser.cs
@@ -44,6 +44,13 @@ namespace aiof.auth.data
         [Required]
         [MaxLength(100)]
         string SecondaryApiKey { get; set; }
+        
+        [JsonIgnore]
+        [Required]
+        int RoleId { get; set; }
+        
+        [Required]
+        Role Role { get; set; }
 
         [Required]
         DateTime Created { get; set; }

--- a/aiof.auth.data/Keys.cs
+++ b/aiof.auth.data/Keys.cs
@@ -5,6 +5,7 @@ namespace aiof.auth.data
     public static class Keys
     {
         public const string ApplicationJson = "application/json";
+        public const string ApplicationProblemJson = "application/problem+json";
 
         public const string MemCache = nameof(MemCache);
         public const string Ttl = nameof(Ttl);

--- a/aiof.auth.data/Role.cs
+++ b/aiof.auth.data/Role.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
@@ -26,19 +27,23 @@ namespace aiof.auth.data
         public const string Admin = nameof(Admin);
         public const string User = nameof(User);
         public const string Client = nameof(Client);
+        public const string Basic = nameof(Basic);
 
 
-        public const string AdminOrUser = nameof(Admin) + "," + nameof(User);
-        public const string AdminOrClient = nameof(Admin) + "," + nameof(Client);
-
-        public const string Any = nameof(Admin) + "," + nameof(User) + "," + nameof(Client);
+        public static string AdminOrUser = Combine(Admin, User);
+        public static string AdminOrClient = Combine(Admin, Client);
+        public static string BasicOrUser = Combine(Basic, User);
+        public static string BasicOrClient = Combine(Basic, Client);
+        public static string Any = Combine(All.ToArray());
+        public static string Combine(params string[] roles) => string.Join(",", roles);
 
         public static IEnumerable<string> All 
             => new string[]
             {
                 Admin,
                 User,
-                Client
+                Client,
+                Basic
             };
     }
 }

--- a/aiof.auth.data/Role.cs
+++ b/aiof.auth.data/Role.cs
@@ -25,5 +25,9 @@ namespace aiof.auth.data
         public const string Admin = nameof(Admin);
         public const string User = nameof(User);
         public const string Client = nameof(Client);
+
+        public const string AdminOrUser = nameof(Admin) + "," + nameof(User);
+        public const string AdminOrClient = nameof(Admin) + "," + nameof(Client);
+        public const string AdminOrUserOrClient = nameof(Admin) + "," + nameof(User) + "," + nameof(Client);
     }
 }

--- a/aiof.auth.data/Role.cs
+++ b/aiof.auth.data/Role.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
 namespace aiof.auth.data
 {
-    public class Role :
+    public class Role : IRole,
         IPublicKeyId
     {
         [Required]
@@ -15,6 +13,7 @@ namespace aiof.auth.data
         public Guid PublicKey { get; set; } = Guid.NewGuid();
 
         [Required]
+        [MaxLength(50)]
         public string Name { get; set; }
     }
 

--- a/aiof.auth.data/Role.cs
+++ b/aiof.auth.data/Role.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
@@ -26,8 +27,18 @@ namespace aiof.auth.data
         public const string User = nameof(User);
         public const string Client = nameof(Client);
 
+
         public const string AdminOrUser = nameof(Admin) + "," + nameof(User);
         public const string AdminOrClient = nameof(Admin) + "," + nameof(Client);
-        public const string AdminOrUserOrClient = nameof(Admin) + "," + nameof(User) + "," + nameof(Client);
+
+        public const string Any = nameof(Admin) + "," + nameof(User) + "," + nameof(Client);
+
+        public static IEnumerable<string> All 
+            => new string[]
+            {
+                Admin,
+                User,
+                Client
+            };
     }
 }

--- a/aiof.auth.data/Role.cs
+++ b/aiof.auth.data/Role.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
 namespace aiof.auth.data
@@ -6,9 +7,11 @@ namespace aiof.auth.data
     public class Role : IRole,
         IPublicKeyId
     {
+        [JsonIgnore]
         [Required]
         public int Id { get; set; }
 
+        [JsonIgnore]
         [Required]
         public Guid PublicKey { get; set; } = Guid.NewGuid();
 

--- a/aiof.auth.data/Role.cs
+++ b/aiof.auth.data/Role.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.auth.data
+{
+    public class Role :
+        IPublicKeyId
+    {
+        [Required]
+        public int Id { get; set; }
+
+        [Required]
+        public Guid PublicKey { get; set; } = Guid.NewGuid();
+
+        [Required]
+        public string Name { get; set; }
+    }
+
+    public static class Roles
+    {
+        public const string Admin = nameof(Admin);
+        public const string User = nameof(User);
+        public const string Client = nameof(Client);
+    }
+}

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -50,6 +50,9 @@ namespace aiof.auth.data
         public DateTime Created { get; set; } = DateTime.UtcNow;
 
         [JsonIgnore]
+        public Role Role { get; set; }
+
+        [JsonIgnore]
         public ICollection<UserRefreshToken> RefreshTokens { get; set; } = new List<UserRefreshToken>();
     }
 

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -81,5 +81,7 @@ namespace aiof.auth.data
         [Required]
         [MaxLength(100)]
         public string Password { get; set; }
+
+        public int? RoleId { get; set; }
     }
 }

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -46,15 +46,15 @@ namespace aiof.auth.data
         [MaxLength(100)]
         public string SecondaryApiKey { get; set; }
 
-        [Required]
-        public DateTime Created { get; set; } = DateTime.UtcNow;
-
         [JsonIgnore]
         [Required]
         public int RoleId { get; set; }
         
         [Required]
         public Role Role { get; set; }
+
+        [Required]
+        public DateTime Created { get; set; } = DateTime.UtcNow;
 
         [JsonIgnore]
         public ICollection<UserRefreshToken> RefreshTokens { get; set; } = new List<UserRefreshToken>();

--- a/aiof.auth.data/User.cs
+++ b/aiof.auth.data/User.cs
@@ -50,6 +50,10 @@ namespace aiof.auth.data
         public DateTime Created { get; set; } = DateTime.UtcNow;
 
         [JsonIgnore]
+        [Required]
+        public int RoleId { get; set; }
+        
+        [Required]
         public Role Role { get; set; }
 
         [JsonIgnore]

--- a/aiof.auth.services/AuthRepository.cs
+++ b/aiof.auth.services/AuthRepository.cs
@@ -116,7 +116,8 @@ namespace aiof.auth.services
         {
             var token = GenerateJwtToken<User>(new Claim[]
                 {
-                    new Claim(AiofClaims.PublicKey, user.PublicKey.ToString())
+                    new Claim(AiofClaims.PublicKey, user.PublicKey.ToString()),
+                    new Claim(AiofClaims.Role, user.Role.Name)
                 },
                 entity: user as IPublicKeyId,
                 refreshToken: refreshToken,
@@ -139,7 +140,8 @@ namespace aiof.auth.services
         {
             return GenerateJwtToken<Client>(new Claim[]
                 {
-                    new Claim(AiofClaims.PublicKey, client.PublicKey.ToString())
+                    new Claim(AiofClaims.PublicKey, client.PublicKey.ToString()),
+                    new Claim(AiofClaims.Role, client.Role.Name)
                 },
                 entity: client as IPublicKeyId,
                 refreshToken: refreshToken,

--- a/aiof.auth.services/ClientRepository.cs
+++ b/aiof.auth.services/ClientRepository.cs
@@ -18,23 +18,26 @@ namespace aiof.auth.services
     public class ClientRepository : BaseRepository, IClientRepository
     {
         private readonly ILogger<ClientRepository> _logger;
-        private readonly IMapper _mapper;
         private readonly IEnvConfiguration _envConfig;
+        private readonly IUtilRepository _utilRepo;
+        private readonly IMapper _mapper;
         private readonly AuthContext _context;
         private readonly AbstractValidator<ClientDto> _clientDtoValidator;
 
         public ClientRepository(
             ILogger<ClientRepository> logger,
-            IMemoryCache cache,
-            IMapper mapper,
             IEnvConfiguration envConfig,
+            IUtilRepository utilRepo,
+            IMapper mapper,
+            IMemoryCache cache,
             AuthContext context,
             AbstractValidator<ClientDto> clientDtoValidator)
             : base(logger, cache, envConfig, context)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
             _envConfig = envConfig ?? throw new ArgumentNullException(nameof(envConfig));
+            _utilRepo = utilRepo ?? throw new ArgumentNullException(nameof(utilRepo));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _clientDtoValidator = clientDtoValidator ?? throw new ArgumentNullException(nameof(clientDtoValidator));
         }
@@ -126,6 +129,8 @@ namespace aiof.auth.services
 
             var client = _mapper.Map<Client>(clientDto)
                 .GenerateApiKeys();
+
+            client.Role = await _utilRepo.GetRoleAsync<Client>(clientDto.RoleId) as Role;
 
             await _context.Clients
                 .AddAsync(client);

--- a/aiof.auth.services/IClientRepository.cs
+++ b/aiof.auth.services/IClientRepository.cs
@@ -8,8 +8,12 @@ namespace aiof.auth.services
 {
     public interface IClientRepository
     {
-        Task<IClient> GetClientAsync(int id);
-        Task<IClient> GetClientAsync(string apiKey);
+        Task<IClient> GetAsync(
+            int id,
+            bool asNoTracking = true);
+        Task<IClient> GetAsync(
+            string apiKey,
+            bool asNoTracking = true);
         Task<IClientRefreshToken> GetRefreshTokenAsync(
             string token,
             bool asNoTracking = true);

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -13,7 +13,7 @@ namespace aiof.auth.services
         Task<IUser> GetUserAsync(string apiKey);
         Task<IUser> GetUserByUsernameAsync(
             string username, 
-            bool asNoTracking = true);
+            bool asNoTracking = false);
         Task<IUser> GetUserAsync(
             string username, 
             string password);

--- a/aiof.auth.services/IUtilRepository.cs
+++ b/aiof.auth.services/IUtilRepository.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Security.Claims;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using aiof.auth.data;
+
+namespace aiof.auth.services
+{
+    public interface IUtilRepository
+    {
+        Task<IRole> GetRoleAsync<T>(
+            int id,
+            bool asNoTracking = true)
+            where T : IPublicKeyId;
+    }
+}

--- a/aiof.auth.services/IUtilRepository.cs
+++ b/aiof.auth.services/IUtilRepository.cs
@@ -11,7 +11,7 @@ namespace aiof.auth.services
     {
         Task<IRole> GetRoleAsync<T>(
             int? id,
-            bool asNoTracking = true)
+            bool asNoTracking = false)
             where T : IPublicKeyId;
     }
 }

--- a/aiof.auth.services/IUtilRepository.cs
+++ b/aiof.auth.services/IUtilRepository.cs
@@ -10,7 +10,7 @@ namespace aiof.auth.services
     public interface IUtilRepository
     {
         Task<IRole> GetRoleAsync<T>(
-            int id,
+            int? id,
             bool asNoTracking = true)
             where T : IPublicKeyId;
     }

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -20,6 +20,7 @@ namespace aiof.auth.services
     {
         private readonly ILogger<UserRepository> _logger;
         private readonly IEnvConfiguration _envConfig;
+        private readonly IUtilRepository _utilRepo;
         private readonly IMapper _mapper;
         private readonly AuthContext _context;
         private readonly AbstractValidator<UserDto> _userDtoValidator;
@@ -27,8 +28,8 @@ namespace aiof.auth.services
 
         public UserRepository(
             ILogger<UserRepository> logger,
-            IMemoryCache cache,
             IEnvConfiguration envConfig,
+            IUtilRepository utilRepo,
             IMapper mapper,
             AuthContext context,
             AbstractValidator<UserDto> userDtoValidator,
@@ -36,6 +37,7 @@ namespace aiof.auth.services
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _envConfig = envConfig ?? throw new ArgumentNullException(nameof(envConfig));
+            _utilRepo = utilRepo ?? throw new ArgumentNullException(nameof(utilRepo));
             _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _userDtoValidator = userDtoValidator ?? throw new ArgumentNullException(nameof(userDtoValidator));
@@ -186,9 +188,7 @@ namespace aiof.auth.services
                     $"and Username='{userDto.Username}' already exists");
 
             user.Password = Hash(userDto.Password);
-
-            // TODO Default User's Role if not specified
-            
+            user.Role = await _utilRepo.GetRoleAsync<User>(userDto.RoleId) as Role;
 
             await _context.Users
                 .AddAsync(user);

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -187,6 +187,9 @@ namespace aiof.auth.services
 
             user.Password = Hash(userDto.Password);
 
+            // TODO Default User's Role if not specified
+            
+
             await _context.Users
                 .AddAsync(user);
 

--- a/aiof.auth.services/UtilRepository.cs
+++ b/aiof.auth.services/UtilRepository.cs
@@ -25,7 +25,7 @@ namespace aiof.auth.services
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        private IQueryable<Role> GetRolesQuery(bool asNoTracking = true)
+        private IQueryable<Role> GetRolesQuery(bool asNoTracking = false)
         {
             return asNoTracking
                 ? _context.Roles
@@ -37,7 +37,7 @@ namespace aiof.auth.services
 
         public async Task<IRole> GetRoleAsync<T>(
             int? id,
-            bool asNoTracking = true)
+            bool asNoTracking = false)
             where T : IPublicKeyId
         {
             var defaultRole = string.Empty;

--- a/aiof.auth.services/UtilRepository.cs
+++ b/aiof.auth.services/UtilRepository.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Linq;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using aiof.auth.data;
+
+namespace aiof.auth.services
+{
+    public class UtilRepository
+    {
+        private readonly ILogger<UtilRepository> _logger;
+        private readonly AuthContext _context;
+
+        public UtilRepository(
+            ILogger<UtilRepository> logger,
+            AuthContext context)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        private IQueryable<Role> GetRolesQuery(bool asNoTracking = true)
+        {
+            return asNoTracking
+                ? _context.Roles
+                    .AsNoTracking()
+                    .AsQueryable()
+                : _context.Roles
+                    .AsQueryable();
+        }
+
+        public async Task<IRole> GetRoleAsync<T>(
+            int id,
+            bool asNoTracking = true)
+            where T : IPublicKeyId
+        {
+            var defaultRole = string.Empty;
+            
+            switch (typeof(T).Name)
+            {
+                case nameof(User):
+                    defaultRole = Roles.User;
+                    break;
+                case nameof(Client):
+                    defaultRole = Roles.Client;
+                    break;
+                default:
+                    defaultRole = Roles.User;
+                    break;
+            }
+
+            defaultRole = defaultRole ?? throw new AuthFriendlyException(HttpStatusCode.BadRequest,
+                $"Invalid request for a {nameof(Role)}. The currently supported entities are: {nameof(User)}, {nameof(Client)}");
+
+            return await GetRolesQuery(asNoTracking)
+                .FirstOrDefaultAsync(x => x.Id == id)
+                ?? await GetRolesQuery(asNoTracking)
+                    .FirstOrDefaultAsync(x => x.Name == defaultRole);
+        }
+    }
+}

--- a/aiof.auth.services/UtilRepository.cs
+++ b/aiof.auth.services/UtilRepository.cs
@@ -59,7 +59,19 @@ namespace aiof.auth.services
             return await GetRolesQuery(asNoTracking)
                 .FirstOrDefaultAsync(x => x.Id == id)
                 ?? await GetRolesQuery(asNoTracking)
-                    .FirstOrDefaultAsync(x => x.Name == defaultRole);
+                    .FirstOrDefaultAsync(x => x.Name == defaultRole)
+                    ?? await QuickAddRoleAsync(defaultRole);
+        }
+
+        public async Task<IRole> QuickAddRoleAsync(
+            string name)
+        {
+            var role = new Role { Name = name };
+            
+            await _context.Roles.AddAsync(role);
+            await _context.SaveChangesAsync();
+
+            return role;
         }
     }
 }

--- a/aiof.auth.services/UtilRepository.cs
+++ b/aiof.auth.services/UtilRepository.cs
@@ -71,6 +71,8 @@ namespace aiof.auth.services
             await _context.Roles.AddAsync(role);
             await _context.SaveChangesAsync();
 
+            _logger.LogInformation($"Created {nameof(Role)}='{name}'");
+
             return role;
         }
     }

--- a/aiof.auth.services/UtilRepository.cs
+++ b/aiof.auth.services/UtilRepository.cs
@@ -36,7 +36,7 @@ namespace aiof.auth.services
         }
 
         public async Task<IRole> GetRoleAsync<T>(
-            int id,
+            int? id,
             bool asNoTracking = true)
             where T : IPublicKeyId
         {

--- a/aiof.auth.services/UtilRepository.cs
+++ b/aiof.auth.services/UtilRepository.cs
@@ -33,6 +33,15 @@ namespace aiof.auth.services
                     .AsQueryable();
         }
 
+        /// <summary>
+        /// Get a Role by id. If the id is null, then a default role is assigned and retrieved from the database.
+        /// If the Role still doesn't exist in the database, then it's added. The default roles are assigned
+        /// based on T name (User, Client, etc.)
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id"></param>
+        /// <param name="asNoTracking"></param>
+        /// <returns></returns>
         public async Task<IRole> GetRoleAsync<T>(
             int? id,
             bool asNoTracking = false)
@@ -49,7 +58,7 @@ namespace aiof.auth.services
                     defaultRole = Roles.Client;
                     break;
                 default:
-                    defaultRole = Roles.User;
+                    defaultRole = Roles.Basic;
                     break;
             }
 
@@ -63,6 +72,11 @@ namespace aiof.auth.services
                     ?? await QuickAddRoleAsync(defaultRole);
         }
 
+        /// <summary>
+        /// Add Role in a quick and invalidated way
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public async Task<IRole> QuickAddRoleAsync(
             string name)
         {

--- a/aiof.auth.services/UtilRepository.cs
+++ b/aiof.auth.services/UtilRepository.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Net;
 using System.Linq;
-using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;

--- a/aiof.auth.services/UtilRepository.cs
+++ b/aiof.auth.services/UtilRepository.cs
@@ -12,7 +12,7 @@ using aiof.auth.data;
 
 namespace aiof.auth.services
 {
-    public class UtilRepository
+    public class UtilRepository : IUtilRepository
     {
         private readonly ILogger<UtilRepository> _logger;
         private readonly AuthContext _context;

--- a/aiof.auth.tests/ClientRepository.Tests.cs
+++ b/aiof.auth.tests/ClientRepository.Tests.cs
@@ -23,7 +23,7 @@ namespace aiof.auth.tests
         [MemberData(nameof(Helper.ClientsId), MemberType = typeof(Helper))]
         public async Task GetClientAsync_By_Id(int id)
         {
-            var client = await _repo.GetClientAsync(id);
+            var client = await _repo.GetAsync(id);
 
             Assert.NotNull(client);
             Assert.Equal(id, client.Id);
@@ -35,7 +35,7 @@ namespace aiof.auth.tests
         [MemberData(nameof(Helper.ClientsApiKey), MemberType = typeof(Helper))]
         public async Task GetClientAsync_By_ApiKey(string apiKey)
         {
-            var client = await _repo.GetClientAsync(apiKey);
+            var client = await _repo.GetAsync(apiKey);
 
             Assert.NotNull(client);
             Assert.NotNull(client.PrimaryApiKey);
@@ -91,7 +91,7 @@ namespace aiof.auth.tests
             Assert.NotNull(client);
             Assert.False(client.Enabled);
 
-            var clientInDb = await _repo.GetClientAsync(id);
+            var clientInDb = await _repo.GetAsync(id);
 
             Assert.NotNull(clientInDb);
         }

--- a/aiof.auth.tests/Helper.cs
+++ b/aiof.auth.tests/Helper.cs
@@ -274,6 +274,13 @@ namespace aiof.auth.tests
         public const string Category = nameof(Category);
         public const string UnitTest = nameof(UnitTest);
         public const string IntegrationTest = nameof(IntegrationTest);
+
+        
+        public class TestPublicKeyId : IPublicKeyId
+        {
+            public int Id { get; set; }
+            public Guid PublicKey { get; set; } = Guid.NewGuid();
+        }
         #endregion
     }
 }

--- a/aiof.auth.tests/Helper.cs
+++ b/aiof.auth.tests/Helper.cs
@@ -63,6 +63,7 @@ namespace aiof.auth.tests
             services.AddScoped<IUserRepository, UserRepository>();
             services.AddScoped<IClientRepository, ClientRepository>();
             services.AddScoped<IAuthRepository, AuthRepository>();
+            services.AddScoped<IUtilRepository, UtilRepository>();
             services.AddScoped<FakeDataManager>();
             services.AddSingleton<IEnvConfiguration, EnvConfiguration>();
 

--- a/aiof.auth.tests/UtilRepository.Tests.cs
+++ b/aiof.auth.tests/UtilRepository.Tests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Xunit;
+
+using aiof.auth.data;
+using aiof.auth.services;
+
+namespace aiof.auth.tests
+{
+    [Trait(Helper.Category, Helper.UnitTest)]
+    public class UtilRepositoryTests
+    {
+        private readonly IUtilRepository _repo;
+
+        public UtilRepositoryTests()
+        {
+            _repo = Helper.GetRequiredService<IUtilRepository>() ?? throw new ArgumentNullException(nameof(IUtilRepository));
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(77)]
+        [InlineData(88)]
+        [InlineData(99)]
+        public async Task GetRoleAsync_User_WithId_Defaults(int id)
+        {
+            var role = await _repo.GetRoleAsync<User>(id);
+
+            Assert.NotNull(role);
+            Assert.Equal(role.Name, Roles.User);
+        }
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(77)]
+        [InlineData(88)]
+        [InlineData(99)]
+        public async Task GetRoleAsync_Client_WithId_Defaults(int id)
+        {
+            var role = await _repo.GetRoleAsync<Client>(id);
+
+            Assert.NotNull(role);
+            Assert.Equal(role.Name, Roles.Client);
+        }
+    }
+}

--- a/aiof.auth.tests/UtilRepository.Tests.cs
+++ b/aiof.auth.tests/UtilRepository.Tests.cs
@@ -44,5 +44,18 @@ namespace aiof.auth.tests
             Assert.NotNull(role);
             Assert.Equal(role.Name, Roles.Client);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(77)]
+        [InlineData(88)]
+        [InlineData(99)]
+        public async Task GetRoleAsync_Non_UserOrClient_Defaults(int? id)
+        {
+            var role = await _repo.GetRoleAsync<Helper.TestPublicKeyId>(id);
+
+            Assert.NotNull(role);
+            Assert.Equal(Roles.Basic, role.Name);
+        }
     }
 }


### PR DESCRIPTION
Added `role` to User and Client entities. These roles will be used to authorize an entity, The current supported roles are:
- `Admin`
- `User`
- `Client`

The different endpoints use different Role authorization

Also:
- Added role based authorization functionality and to all endpoints
- Added `Role` to EF context and a foreign relationship to `User` and `Client`
- Added middleware for http responses for `Unauthorized` and `Forbidden` to return a simple Code/Message object
- Added `UtilRepository` to keep common functionality such as getting roles in a common class
- Added `UtilRepository` to User and Client repository
- Updated `User` and `Client` repo to not fully use the `BaseRepository`