### PR TITLE
bug/2021.07/enable-disabled-client

### DIFF
--- a/aiof.auth.core/Controllers/ClientController.cs
+++ b/aiof.auth.core/Controllers/ClientController.cs
@@ -73,7 +73,7 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Regenerate PrimaryApiKey and SecondaryApiKey of Client
         /// </summary>
-        [HttpGet]
+        [HttpPost]
         [Route("{id}/regenerate/keys")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IClient), StatusCodes.Status200OK)]

--- a/aiof.auth.core/Controllers/ClientController.cs
+++ b/aiof.auth.core/Controllers/ClientController.cs
@@ -49,25 +49,25 @@ namespace aiof.auth.core.Controllers
         /// <summary>
         /// Disable Client
         /// </summary>
-        [HttpGet]
+        [HttpPost]
         [Route("{id}/disable")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IClient), StatusCodes.Status200OK)]
         public async Task<IActionResult> DisableClientAsync([FromRoute, Required] int id)
         {
-            return Ok(await _repo.EnableDisableClientAsync(id, false));
+            return Ok(await _repo.DisableAsync(id));
         }
 
         /// <summary>
         /// Enable Client
         /// </summary>
-        [HttpGet]
+        [HttpPost]
         [Route("{id}/enable")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IClient), StatusCodes.Status200OK)]
         public async Task<IActionResult> EnableClientAsync([FromRoute, Required] int id)
         {
-            return Ok(await _repo.EnableDisableClientAsync(id));
+            return Ok(await _repo.EnableAsync(id));
         }
 
         /// <summary>

--- a/aiof.auth.data/AuthContext.cs
+++ b/aiof.auth.data/AuthContext.cs
@@ -71,8 +71,6 @@ namespace aiof.auth.data
                 e.ToTable(Keys.Entity.Client);
 
                 e.HasKey(x => x.Id);
-
-                e.HasQueryFilter(x => x.Enabled);
                 
                 e.Property(x => x.Id).HasSnakeCaseColumnName().ValueGeneratedOnAdd().IsRequired();
                 e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();

--- a/aiof.auth.services/AuthRepository.cs
+++ b/aiof.auth.services/AuthRepository.cs
@@ -82,7 +82,12 @@ namespace aiof.auth.services
                         userRefreshToken.Token);
                 case nameof(Client):
                     var client = await _clientRepo.GetAsync(apiKey);
-                    var clientRefreshToken = await _clientRepo.GetOrAddRefreshTokenAsync(apiKey);
+                    
+                    if (client.Enabled is false)
+                        throw new AuthFriendlyException(HttpStatusCode.BadRequest,
+                            $"Client is disabled");
+
+                    var clientRefreshToken = await _clientRepo.GetOrAddRefreshTokenAsync(client);
                     return GenerateJwt(
                         client,
                         clientRefreshToken.Token);

--- a/aiof.auth.services/BaseRepository.cs
+++ b/aiof.auth.services/BaseRepository.cs
@@ -99,8 +99,9 @@ namespace aiof.auth.services
 
             await _context.SaveChangesAsync();
 
-            _logger.LogInformation("Regenerated Keys for {EntityName} with Id='{id}' and PublicKey='{EntityPublicKey}'",
+            _logger.LogInformation("Regenerated Keys for {EntityName} with Id={id} and PublicKey={EntityPublicKey}",
                 typeof(T).Name,
+                id,
                 entity.PublicKey);
 
             return entity;

--- a/aiof.auth.services/ClientRepository.cs
+++ b/aiof.auth.services/ClientRepository.cs
@@ -115,14 +115,8 @@ namespace aiof.auth.services
                 .ToListAsync();
         }
 
-        public async Task<IClientRefreshToken> GetOrAddRefreshTokenAsync(string clientApiKey)
+        public async Task<IClientRefreshToken> GetOrAddRefreshTokenAsync(IClient client)
         {
-            var client = await GetAsync(clientApiKey);
-
-            if (!client.Enabled)
-                throw new AuthFriendlyException(HttpStatusCode.BadRequest,
-                    $"The current Client with ApiKey='{clientApiKey}' is DISABLED");
-
             var clientRefreshToken = await GetRefreshTokenAsync(client.Id)
                 ?? await AddRefreshTokenAsync(client.Id);
 

--- a/aiof.auth.services/ClientRepository.cs
+++ b/aiof.auth.services/ClientRepository.cs
@@ -195,17 +195,16 @@ namespace aiof.auth.services
             return clientRefreshToken;
         }
 
-        public async Task<IClient> SoftDeleteAsync(int id)
+        public async Task<IClient> EnableAsync(int id)
         {
-            return await base.SoftDeleteAsync<Client>(id);
+            return await EnableDisableClientAsync(id);
+        }
+        public async Task<IClient> DisableAsync(int id)
+        {
+            return await EnableDisableClientAsync(id, false);
         }
 
-        public async Task<IClient> RegenerateKeysAsync(int id)
-        {
-            return await base.RegenerateKeysAync<Client>(id);
-        }
-
-        public async Task<IClient> EnableDisableClientAsync(
+        private async Task<IClient> EnableDisableClientAsync(
             int id,
             bool enable = true)
         {
@@ -216,6 +215,11 @@ namespace aiof.auth.services
             await _context.SaveChangesAsync();
 
             return client;
+        }
+        
+        public async Task<IClient> RegenerateKeysAsync(int id)
+        {
+            return await base.RegenerateKeysAync<Client>(id);
         }
     }
 }

--- a/aiof.auth.services/IClientRepository.cs
+++ b/aiof.auth.services/IClientRepository.cs
@@ -26,8 +26,8 @@ namespace aiof.auth.services
         Task<IClient> AddClientAsync(ClientDto clientDto);
         IAsyncEnumerable<IClient> AddClientsAsync(IEnumerable<ClientDto> clientDtos);
         Task<IClientRefreshToken> RevokeTokenAsync(int clientId, string token);
-        Task<IClient> SoftDeleteAsync(int id);
+        Task<IClient> EnableAsync(int id);
+        Task<IClient> DisableAsync(int id);
         Task<IClient> RegenerateKeysAsync(int id);
-        Task<IClient> EnableDisableClientAsync(int id, bool enable = true);
     }
 }

--- a/aiof.auth.services/IClientRepository.cs
+++ b/aiof.auth.services/IClientRepository.cs
@@ -22,7 +22,7 @@ namespace aiof.auth.services
             string refreshToken, 
             bool asNoTracking = true);
         Task<IEnumerable<IClientRefreshToken>> GetRefreshTokensAsync(int clientId);
-        Task<IClientRefreshToken> GetOrAddRefreshTokenAsync(string clientApiKey);
+        Task<IClientRefreshToken> GetOrAddRefreshTokenAsync(IClient client);
         Task<IClient> AddClientAsync(ClientDto clientDto);
         IAsyncEnumerable<IClient> AddClientsAsync(IEnumerable<ClientDto> clientDtos);
         Task<IClientRefreshToken> RevokeTokenAsync(int clientId, string token);

--- a/aiof.auth.tests/ClientRepository.Tests.cs
+++ b/aiof.auth.tests/ClientRepository.Tests.cs
@@ -97,16 +97,26 @@ namespace aiof.auth.tests
 
         [Theory]
         [MemberData(nameof(Helper.ClientsId), MemberType = typeof(Helper))]
-        public async Task SoftDeleteAsync_IsSuccessful(int id)
+        public async Task EnableClientAsync_IsSuccessful(int id)
         {
             var repo = new ServiceHelper().GetRequiredService<IClientRepository>();
 
-            var client = await repo.SoftDeleteAsync(id);
+            var client = await repo.EnableAsync(id);
+
+            Assert.NotNull(client);
+            Assert.True(client.Enabled);
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.ClientsId), MemberType = typeof(Helper))]
+        public async Task DisableClientAsync_IsSuccessful(int id)
+        {
+            var repo = new ServiceHelper().GetRequiredService<IClientRepository>();
+
+            var client = await repo.DisableAsync(id);
 
             Assert.NotNull(client);
             Assert.False(client.Enabled);
-
-            await Assert.ThrowsAsync<AuthNotFoundException>(() => repo.GetAsync(id));
         }
     }
 }

--- a/aiof.auth.tests/ClientRepository.Tests.cs
+++ b/aiof.auth.tests/ClientRepository.Tests.cs
@@ -118,5 +118,24 @@ namespace aiof.auth.tests
             Assert.NotNull(client);
             Assert.False(client.Enabled);
         }
+
+        [Theory]
+        [MemberData(nameof(Helper.ClientsId), MemberType = typeof(Helper))]
+        public async Task RegenerateKeysAsync_IsSuccessful(int id)
+        {
+            var repo = new ServiceHelper().GetRequiredService<IClientRepository>();
+
+            var client = await repo.GetAsync(id);
+            var pKey = client.PrimaryApiKey;
+            var sKey = client.SecondaryApiKey;           
+
+            Assert.NotNull(client);
+
+            client = await repo.RegenerateKeysAsync(id);
+
+            Assert.NotNull(client);
+            Assert.NotEqual(pKey, client.PrimaryApiKey);
+            Assert.NotEqual(sKey, client.SecondaryApiKey);
+        }
     }
 }


### PR DESCRIPTION
Closes #19 

**Additional**
- split enable, disable methods
- updated endpoints to be `HttpPost` instead of `HttpGet`
- updated existing and added more unit tests