### PR TITLE
feature/2021.07/add-fv-rulesets

### DIFF
--- a/aiof.auth.core/Controllers/AuthController.cs
+++ b/aiof.auth.core/Controllers/AuthController.cs
@@ -87,7 +87,7 @@ namespace aiof.auth.core.Controllers
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
-        public async Task<IActionResult> RevokeClientRefreshTokenAsync([FromQuery, Required] int id)
+        public async Task<IActionResult> RevokeClientRefreshTokenAsync([FromRoute, Required] int id)
         {
             await _repo.RevokeClientAsync(id);
             
@@ -105,7 +105,7 @@ namespace aiof.auth.core.Controllers
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
-        public async Task<IActionResult> RevokeUserRefreshTokenAsync([FromQuery, Required] int id)
+        public async Task<IActionResult> RevokeUserRefreshTokenAsync([FromRoute, Required] int id)
         {
             await _repo.RevokeUserAsync(id);
 

--- a/aiof.auth.core/Controllers/AuthController.cs
+++ b/aiof.auth.core/Controllers/AuthController.cs
@@ -81,15 +81,17 @@ namespace aiof.auth.core.Controllers
         /// </summary>
         [Authorize(Roles = Roles.Admin)]
         [HttpPut]
-        [Route("token/client/revoke")]
+        [Route("token/client/{id}/revoke")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
-        public async Task<IActionResult> RevokeClientRefreshTokenAsync([FromBody, Required] RevokeClientRequest request)
+        public async Task<IActionResult> RevokeClientRefreshTokenAsync([FromQuery, Required] int id)
         {
-            return Ok(await _repo.RevokeTokenAsync(request.Token, clientId: request.ClientId));
+            await _repo.RevokeClientAsync(id);
+            
+            return Ok();
         }
 
         /// <summary>
@@ -97,15 +99,17 @@ namespace aiof.auth.core.Controllers
         /// </summary>
         [Authorize(Roles = Roles.Admin)]
         [HttpPut]
-        [Route("token/user/revoke")]
+        [Route("token/user/{id}/revoke")]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(IAuthProblemDetail), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(IAuthProblemDetailBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(IRevokeResponse), StatusCodes.Status200OK)]
-        public async Task<IActionResult> RevokeUserRefreshTokenAsync([FromBody, Required] RevokeUserRequest request)
+        public async Task<IActionResult> RevokeUserRefreshTokenAsync([FromQuery, Required] int id)
         {
-            return Ok(await _repo.RevokeTokenAsync(request.Token, userId: request.UserId));
+            await _repo.RevokeUserAsync(id);
+
+            return Ok();
         }
 
         /// <summary>

--- a/aiof.auth.data/Constants.cs
+++ b/aiof.auth.data/Constants.cs
@@ -27,6 +27,9 @@ namespace aiof.auth.data
             };
         public static string DefaultUnsupportedApiVersionMessage = $"Unsupported API version specified. The supported versions are {string.Join(", ", ApiSupportedVersions)}";
 
+        public static string EmailPasswordRuleSet = nameof(EmailPasswordRuleSet);
+        public static string ApiKeyRuleSet = nameof(ApiKeyRuleSet);
+        public static string TokenRuleSet = nameof(TokenRuleSet);
     }
 
     public static class Keys

--- a/aiof.auth.data/Constants.cs
+++ b/aiof.auth.data/Constants.cs
@@ -116,9 +116,17 @@ namespace aiof.auth.data
         }
     }
 
+    public enum TokenType
+    {
+        NoMatch,
+        User,
+        ApiKey,
+        Refresh
+    }
+
     public enum TokenStatus
     {
-        Valid = 1,
+        Valid,
         Invalid,
         Expired
     }

--- a/aiof.auth.data/ExtensionMethods.cs
+++ b/aiof.auth.data/ExtensionMethods.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading.Tasks;
+
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace aiof.auth.data
+{
+    public static class ExtensionMethods
+    {
+        public static async Task ValidateAndThrowAsync<T>(
+            this IValidator<T> validator, 
+            T instance,
+            string ruleSet)
+        {
+            var result = await validator.ValidateAsync(instance, o => o.IncludeRuleSets(ruleSet));
+
+            if (!result.IsValid)
+            {
+                throw new ValidationException(result.Errors);
+            }
+        }
+
+        public static async Task ValidateAndThrowAsync<T>(
+            this IValidator<T> validator,
+            T instance)
+        {
+            var result = await validator.ValidateAsync(instance, o => o.IncludeAllRuleSets());
+            
+            if (!result.IsValid)
+            {
+                throw new ValidationException(result.Errors);
+            }
+        }
+    }
+}

--- a/aiof.auth.data/FakeDataManager.cs
+++ b/aiof.auth.data/FakeDataManager.cs
@@ -470,6 +470,14 @@ namespace aiof.auth.data
                         clientRtToken
                     });
             }
+            else if (clientId)
+            {
+                foreach (var rtClientId in clientRefreshTokens.Select(x => x.ClientId).Distinct())
+                    toReturn.Add(new object[]
+                    {
+                        rtClientId
+                    });
+            }
             
             return toReturn;
         }

--- a/aiof.auth.data/ITokenRequest.cs
+++ b/aiof.auth.data/ITokenRequest.cs
@@ -8,7 +8,7 @@ namespace aiof.auth.data
         string Token { get; set; }
         string Email { get; set; }
         string Password { get; set; }
-        TokenType Type { get; set; }
+        TokenType Type { get; }
     }
 
     public interface IRevokeRequest

--- a/aiof.auth.data/IUserRefreshToken.cs
+++ b/aiof.auth.data/IUserRefreshToken.cs
@@ -1,24 +1,13 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.ComponentModel.DataAnnotations;
 
 namespace aiof.auth.data
 {
     public interface IUserRefreshToken
     {
-        [JsonIgnore]
         int Id { get; set; }
-
-        [JsonIgnore]
         Guid PublicKey { get; set; }
-
         string Token { get; set; }
-
-        [JsonIgnore]
         int UserId { get; set; }
-
         DateTime Created { get; set; }
         DateTime Expires { get; set; }
         DateTime? Revoked { get; set; }

--- a/aiof.auth.data/TokenRequest.cs
+++ b/aiof.auth.data/TokenRequest.cs
@@ -53,35 +53,6 @@ namespace aiof.auth.data
     }
 
     /// <summary>
-    /// Request to revoke a refresh token
-    /// </summary>
-    public class RevokeRequest : IRevokeRequest
-    {
-        [JsonPropertyName("refresh_token")]
-        [Required]
-        [MaxLength(128)]
-        public string Token { get; set; }
-    }
-
-    /// <summary>
-    /// Request to revoke a User refresh token
-    /// </summary>
-    public class RevokeUserRequest : RevokeRequest, IRevokeUserRequest
-    {
-        [Required]
-        public int UserId { get; set; }
-    }
-
-    /// <summary>
-    /// Request to revoke a Client refresh token
-    /// </summary>
-    public class RevokeClientRequest : RevokeRequest, IRevokeClientRequest
-    {
-        [Required]
-        public int ClientId { get; set; }
-    }
-
-    /// <summary>
     /// Request to validate an access token
     /// </summary>
     public class ValidationRequest : IValidationRequest

--- a/aiof.auth.data/TokenRequest.cs
+++ b/aiof.auth.data/TokenRequest.cs
@@ -32,23 +32,15 @@ namespace aiof.auth.data
             get
             {
                 if (!string.IsNullOrWhiteSpace(Email)
-                    && !string.IsNullOrWhiteSpace(Password)
-                    && string.IsNullOrWhiteSpace(Token)
-                    && string.IsNullOrWhiteSpace(ApiKey))
+                    && !string.IsNullOrWhiteSpace(Password))
                 {
                     return TokenType.User;
                 }
-                else if (!string.IsNullOrWhiteSpace(ApiKey)
-                    && string.IsNullOrWhiteSpace(Token)
-                    && string.IsNullOrWhiteSpace(Email)
-                    && string.IsNullOrWhiteSpace(Password))
+                else if (!string.IsNullOrWhiteSpace(ApiKey))
                 {
                     return TokenType.ApiKey;
                 }
-                else if (!string.IsNullOrWhiteSpace(Token)
-                    && string.IsNullOrWhiteSpace(Email)
-                    && string.IsNullOrWhiteSpace(Password)
-                    && string.IsNullOrWhiteSpace(ApiKey))
+                else if (!string.IsNullOrWhiteSpace(Token))
                 {
                     return TokenType.Refresh;
                 }
@@ -97,13 +89,5 @@ namespace aiof.auth.data
         [JsonPropertyName("access_token")]
         [Required]
         public string AccessToken { get; set; }
-    }
-
-    public enum TokenType
-    {
-        NoMatch,
-        User,
-        ApiKey,
-        Refresh,
     }
 }

--- a/aiof.auth.data/TokenRequest.cs
+++ b/aiof.auth.data/TokenRequest.cs
@@ -27,7 +27,37 @@ namespace aiof.auth.data
         public string Password { get; set; }
 
         [JsonIgnore]
-        public TokenType Type { get; set; }
+        public TokenType Type
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(Email)
+                    && !string.IsNullOrWhiteSpace(Password)
+                    && string.IsNullOrWhiteSpace(Token)
+                    && string.IsNullOrWhiteSpace(ApiKey))
+                {
+                    return TokenType.User;
+                }
+                else if (!string.IsNullOrWhiteSpace(ApiKey)
+                    && string.IsNullOrWhiteSpace(Token)
+                    && string.IsNullOrWhiteSpace(Email)
+                    && string.IsNullOrWhiteSpace(Password))
+                {
+                    return TokenType.ApiKey;
+                }
+                else if (!string.IsNullOrWhiteSpace(Token)
+                    && string.IsNullOrWhiteSpace(Email)
+                    && string.IsNullOrWhiteSpace(Password)
+                    && string.IsNullOrWhiteSpace(ApiKey))
+                {
+                    return TokenType.Refresh;
+                }
+                else
+                {
+                    return TokenType.NoMatch;
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -71,6 +101,7 @@ namespace aiof.auth.data
 
     public enum TokenType
     {
+        NoMatch,
         User,
         ApiKey,
         Refresh,

--- a/aiof.auth.data/TokenResponse.cs
+++ b/aiof.auth.data/TokenResponse.cs
@@ -29,15 +29,4 @@ namespace aiof.auth.data
         [JsonPropertyName("user")]
         public IUser User { get; set; }
     }
-
-    /// <summary>
-    /// Response to revoke a refresh token
-    /// </summary>
-    public class RevokeResponse : IRevokeResponse
-    {
-        [JsonPropertyName("refresh_token")]
-        public string Token { get; set; }
-
-        public DateTime? Revoked { get; set; }
-    }
 }

--- a/aiof.auth.data/UserRefreshToken.cs
+++ b/aiof.auth.data/UserRefreshToken.cs
@@ -1,25 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.ComponentModel.DataAnnotations;
 
 namespace aiof.auth.data
 {
     public class UserRefreshToken : IUserRefreshToken,
         IPublicKeyId
     {
-        [JsonIgnore]
         public int Id { get; set; }
-
-        [JsonIgnore]
         public Guid PublicKey { get; set; } = Guid.NewGuid();
-
         public string Token { get; set; } = Utils.GenerateApiKey<User>(64);
-
-        [JsonIgnore]
         public int UserId { get; set; }
-
         public DateTime Created { get; set; } = DateTime.UtcNow;
         public DateTime Expires { get; set; }
         public DateTime? Revoked { get; set; }

--- a/aiof.auth.data/Validators/TokenRequestValidator.cs
+++ b/aiof.auth.data/Validators/TokenRequestValidator.cs
@@ -13,15 +13,13 @@ namespace aiof.auth.data
             RuleSet(Constants.EmailPasswordRuleSet, () => { SetEmailPasswordRuleSet(); });
             RuleSet(Constants.ApiKeyRuleSet, () => { SetApiKeyRuleSet(); });
             RuleSet(Constants.TokenRuleSet, () => { SetTokenRuleSet(); });
-
-            // Either Email, Password is provided, ApiKey (Client or User) is provided or RefreshToken
-            //.WithMessage("Invalid token request. Please provide the following: a Email/Password, ApiKey or Token");
         }
 
         public void SetEmailPasswordRuleSet()
         {
             RuleFor(x => x.Email)
                 .NotNull()
+                .EmailAddress()
                 .MaximumLength(200);
 
             RuleFor(x => x.Password)
@@ -45,7 +43,7 @@ namespace aiof.auth.data
 
             RuleFor(x => x.ApiKey)
                 .NotNull()
-                .MaximumLength(100);
+                .MaximumLength(64);
            
             RuleFor(x => x.Token)
                 .Null();
@@ -64,7 +62,7 @@ namespace aiof.auth.data
            
             RuleFor(x => x.Token)
                 .NotNull()
-                .MaximumLength(200);
+                .MaximumLength(128);
         }
     }
 }

--- a/aiof.auth.data/Validators/TokenRequestValidator.cs
+++ b/aiof.auth.data/Validators/TokenRequestValidator.cs
@@ -10,41 +10,61 @@ namespace aiof.auth.data
         {
             ValidatorOptions.Global.CascadeMode = CascadeMode.Stop;
 
-            RuleFor(x => x)
-                .NotNull();
+            RuleSet(Constants.EmailPasswordRuleSet, () => { SetEmailPasswordRuleSet(); });
+            RuleSet(Constants.ApiKeyRuleSet, () => { SetApiKeyRuleSet(); });
+            RuleSet(Constants.TokenRuleSet, () => { SetTokenRuleSet(); });
 
             // Either Email, Password is provided, ApiKey (Client or User) is provided or RefreshToken
-            RuleFor(x => x)
-                .Must(x => 
-                {
-                    if (!string.IsNullOrWhiteSpace(x.Email)
-                        && !string.IsNullOrWhiteSpace(x.Password)
-                        && string.IsNullOrWhiteSpace(x.Token)
-                        && string.IsNullOrWhiteSpace(x.ApiKey))
-                    {
-                        x.Type = TokenType.User;
-                        return true;
-                    }
-                    else if (!string.IsNullOrWhiteSpace(x.ApiKey)
-                        && string.IsNullOrWhiteSpace(x.Token)
-                        && string.IsNullOrWhiteSpace(x.Email)
-                        && string.IsNullOrWhiteSpace(x.Password))
-                    {
-                        x.Type = TokenType.ApiKey;
-                        return true;
-                    }
-                    else if (!string.IsNullOrWhiteSpace(x.Token)
-                        && string.IsNullOrWhiteSpace(x.Email)
-                        && string.IsNullOrWhiteSpace(x.Password)
-                        && string.IsNullOrWhiteSpace(x.ApiKey))
-                    {
-                        x.Type = TokenType.Refresh;
-                        return true;
-                    }
+            //.WithMessage("Invalid token request. Please provide the following: a Email/Password, ApiKey or Token");
+        }
 
-                    return false;
-                })
-                .WithMessage("Invalid token request. Please provide the following: a Email/Password, ApiKey or Token");
+        public void SetEmailPasswordRuleSet()
+        {
+            RuleFor(x => x.Email)
+                .NotNull()
+                .MaximumLength(200);
+
+            RuleFor(x => x.Password)
+                .NotNull()
+                .MaximumLength(100);
+
+            RuleFor(x => x.ApiKey)
+                .Null();
+                
+            RuleFor(x => x.Token)
+                .Null();
+        }
+
+        public void SetApiKeyRuleSet()
+        {
+            RuleFor(x => x.Email)
+                .Null();
+
+            RuleFor(x => x.Password)
+                .Null();
+
+            RuleFor(x => x.ApiKey)
+                .NotNull()
+                .MaximumLength(100);
+           
+            RuleFor(x => x.Token)
+                .Null();
+        }
+
+        public void SetTokenRuleSet()
+        {
+            RuleFor(x => x.Email)
+                .Null();
+
+            RuleFor(x => x.Password)
+                .Null();
+
+            RuleFor(x => x.ApiKey)
+                .Null();
+           
+            RuleFor(x => x.Token)
+                .NotNull()
+                .MaximumLength(200);
         }
     }
 }

--- a/aiof.auth.services/AuthRepository.cs
+++ b/aiof.auth.services/AuthRepository.cs
@@ -69,7 +69,7 @@ namespace aiof.auth.services
                     return await RefreshTokenAsync(request.Token);
                 default:
                     throw new AuthFriendlyException(HttpStatusCode.BadRequest,
-                        $"Invalid token request. Please provide the following: a email/password, api_key or refresh_token");
+                        $"Invalid token request. Please provide the following: an email and password, api_key or refresh_token");
             }
         }
 

--- a/aiof.auth.services/AuthRepository.cs
+++ b/aiof.auth.services/AuthRepository.cs
@@ -262,42 +262,14 @@ namespace aiof.auth.services
             }
         }
 
-        public async Task<IRevokeResponse> RevokeTokenAsync(
-            string token,
-            int? userId = null,
-            int? clientId = null)
+        public async Task RevokeUserAsync(int id)
         {
-            if (clientId != null)
-            {
-                var clientRefresh = await _clientRepo.RevokeTokenAsync((int)clientId, token);
+            await _userRepo.RevokeAsync(id);
+        }
 
-                _logger.LogInformation("Revoked {EntityName} token={EntityToken}",
-                    nameof(ClientRefreshToken),
-                    clientRefresh.Token);
-
-                return new RevokeResponse
-                {
-                    Token = clientRefresh.Token,
-                    Revoked = clientRefresh.Revoked
-                };
-            }
-            else if (userId != null)
-            {
-                var userRefresh = await _userRepo.RevokeTokenAsync((int)userId, token);
-
-                _logger.LogInformation("Revoked {EntityName} token={EntityToken}",
-                    nameof(UserRefreshToken),
-                    userRefresh.Token);
-
-                return new RevokeResponse
-                {
-                    Token = userRefresh.Token,
-                    Revoked = userRefresh.Revoked
-                };
-            }
-            else
-                throw new AuthFriendlyException(HttpStatusCode.BadRequest,
-                    $"Couldn't revoke Token='{token}' for UserId='{userId}' or ClientId='{clientId}'");
+        public async Task RevokeClientAsync(int id)
+        {
+            await _clientRepo.RevokeAsync(id);
         }
 
         public IIntrospectTokenResult Introspect()

--- a/aiof.auth.services/ClientRepository.cs
+++ b/aiof.auth.services/ClientRepository.cs
@@ -177,13 +177,16 @@ namespace aiof.auth.services
         public async Task RevokeAsync(int clientId)
         {
             var now = DateTime.UtcNow;
-            var refreshTokens = (await GetRefreshTokensAsync(clientId, false))
-                as IEnumerable<ClientRefreshToken>;
+            var refreshTokens = await GetRefreshTokensAsync(clientId, false)
+                as List<ClientRefreshToken>;
 
             foreach (var refreshToken in refreshTokens)
             {
                 refreshToken.Revoked = now;
             }
+
+            _context.ClientRefreshTokens
+                .UpdateRange(refreshTokens);
 
             await _context.SaveChangesAsync();
 

--- a/aiof.auth.services/ClientRepository.cs
+++ b/aiof.auth.services/ClientRepository.cs
@@ -87,7 +87,7 @@ namespace aiof.auth.services
         {
             return await GetClientQuery(asNoTracking)
                 .Include(x => x.RefreshTokens)
-                .FirstOrDefaultAsync(x => x.RefreshTokens.Any(x => x.Token == token))
+                .FirstOrDefaultAsync(x => x.RefreshTokens.Any(x => x.Token == token && x.Revoked == null))
                 ?? throw new AuthNotFoundException($"RefreshToken='{token}' was not found");
         }
         public async Task<IClientRefreshToken> GetRefreshTokenAsync(

--- a/aiof.auth.services/ClientRepository.cs
+++ b/aiof.auth.services/ClientRepository.cs
@@ -108,10 +108,14 @@ namespace aiof.auth.services
                     && DateTime.UtcNow < x.Expires);
         }
 
-        public async Task<IEnumerable<IClientRefreshToken>> GetRefreshTokensAsync(int clientId)
+        public async Task<IEnumerable<IClientRefreshToken>> GetRefreshTokensAsync(
+            int clientId,
+            bool asNoTracking = true)
         {
-            return await GetRefreshTokensQuery()
-                .Where(x => x.ClientId == clientId)
+            return await GetRefreshTokensQuery(asNoTracking)
+                .Where(x => x.ClientId == clientId
+                    && x.Revoked == null)
+                .OrderByDescending(x => x.Expires)
                 .ToListAsync();
         }
 
@@ -170,29 +174,22 @@ namespace aiof.auth.services
                 yield return await AddClientAsync(clientDto);
         }
 
-        public async Task<IClientRefreshToken> RevokeTokenAsync(int clientId, string token)
+        public async Task RevokeAsync(int clientId)
         {
-            var clientRefreshToken = await GetRefreshTokenAsync(
-                clientId, 
-                token,
-                asNoTracking: false)
-                as ClientRefreshToken
-                ?? throw new AuthNotFoundException();
+            var now = DateTime.UtcNow;
+            var refreshTokens = (await GetRefreshTokensAsync(clientId, false))
+                as IEnumerable<ClientRefreshToken>;
 
-            clientRefreshToken.Revoked = DateTime.UtcNow;
-            clientRefreshToken.Expires = DateTime.UtcNow;
-
-            _context.ClientRefreshTokens
-                .Update(clientRefreshToken);
+            foreach (var refreshToken in refreshTokens)
+            {
+                refreshToken.Revoked = now;
+            }
 
             await _context.SaveChangesAsync();
 
-            _logger.LogInformation("Revoked {EntityName}={ClientRefreshToken} for CliendId={ClientId}",
+            _logger.LogInformation("Revoked {EntityName}s for UserId={UserId}",
                 nameof(ClientRefreshToken),
-                token,
                 clientId);
-
-            return clientRefreshToken;
         }
 
         public async Task<IClient> EnableAsync(int id)

--- a/aiof.auth.services/IAuthRepository.cs
+++ b/aiof.auth.services/IAuthRepository.cs
@@ -28,10 +28,8 @@ namespace aiof.auth.services
             where T : class, IPublicKeyId;
         RsaSecurityKey GetRsaKey(RsaKeyType rsaKeyType);
         ITokenResult ValidateToken(string token);
-        Task<IRevokeResponse> RevokeTokenAsync(
-            string token,
-            int? userId = null,
-            int? clientId = null);
+        Task RevokeUserAsync(int id);
+        Task RevokeClientAsync(int id);
         IIntrospectTokenResult Introspect();
         JsonWebKey GetPublicJsonWebKey();
         IOpenIdConfig GetOpenIdConfig(

--- a/aiof.auth.services/IClientRepository.cs
+++ b/aiof.auth.services/IClientRepository.cs
@@ -21,11 +21,13 @@ namespace aiof.auth.services
             int clientId, 
             string refreshToken, 
             bool asNoTracking = true);
-        Task<IEnumerable<IClientRefreshToken>> GetRefreshTokensAsync(int clientId);
+        Task<IEnumerable<IClientRefreshToken>> GetRefreshTokensAsync(
+            int clientId,
+            bool asNoTracking = true);
         Task<IClientRefreshToken> GetOrAddRefreshTokenAsync(IClient client);
         Task<IClient> AddClientAsync(ClientDto clientDto);
         IAsyncEnumerable<IClient> AddClientsAsync(IEnumerable<ClientDto> clientDtos);
-        Task<IClientRefreshToken> RevokeTokenAsync(int clientId, string token);
+        Task RevokeAsync(int clientId);
         Task<IClient> EnableAsync(int id);
         Task<IClient> DisableAsync(int id);
         Task<IClient> RegenerateKeysAsync(int id);

--- a/aiof.auth.services/IUserRepository.cs
+++ b/aiof.auth.services/IUserRepository.cs
@@ -30,7 +30,9 @@ namespace aiof.auth.services
         Task<IUser> GetAsync(UserDto userDto);
         Task<IUser> GetByRefreshTokenAsync(string refreshToken);
         Task<IUserRefreshToken> GetRefreshTokenAsync(int userId);
-        Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(int userId);
+        Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(
+            int userId,
+            bool asNoTracking = true);
         Task<IUserRefreshToken> GetOrAddRefreshTokenAsync(int userId);
         Task<bool> DoesEmailExistAsync(string email);
         Task<IUser> AddAsync(UserDto userDto);
@@ -42,9 +44,7 @@ namespace aiof.auth.services
             string email,
             string oldPassword,
             string newPassword);
-        Task<IUserRefreshToken> RevokeTokenAsync(
-            int userId,
-            string token);
+        Task RevokeAsync(int userId);
         string Hash(string password);
         bool Check(string hash, string password);
     }

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -304,13 +304,16 @@ namespace aiof.auth.services
         {
             var now = DateTime.UtcNow;
             var refreshTokens = await GetRefreshTokensAsync(userId, false)
-                as IEnumerable<UserRefreshToken>;
+                as List<UserRefreshToken>;
 
             foreach (var refreshToken in refreshTokens)
             {
-                refreshToken.Revoked = DateTime.UtcNow;
+                refreshToken.Revoked = now;
             }
-
+            
+            _context.UserRefreshTokens
+                .UpdateRange(refreshTokens);
+        
             await _context.SaveChangesAsync();
 
             _logger.LogInformation("Revoked {EntityName}s for UserId={UserId}",

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -138,7 +138,7 @@ namespace aiof.auth.services
                 .Include(x => x.Role)
                 .Include(x => x.RefreshTokens)
                 .AsNoTracking()
-                .FirstOrDefaultAsync(x => x.RefreshTokens.Any(x => x.Token == refreshToken))
+                .FirstOrDefaultAsync(x => x.RefreshTokens.Any(x => x.Token == refreshToken && x.Revoked == null))
                 ?? throw new AuthNotFoundException($"{nameof(User)} with RefreshToken={refreshToken} was not found");
         }
         public async Task<IUserRefreshToken> GetRefreshTokenAsync(int userId)

--- a/aiof.auth.services/UserRepository.cs
+++ b/aiof.auth.services/UserRepository.cs
@@ -54,7 +54,7 @@ namespace aiof.auth.services
         private IQueryable<UserRefreshToken> GetRefreshTokensQuery(bool asNoTracking = true)
         {
             var query = _context.UserRefreshTokens
-                    .AsQueryable();
+                .AsQueryable();
 
             return asNoTracking
                 ? query.AsNoTracking()
@@ -159,13 +159,14 @@ namespace aiof.auth.services
                 .FirstOrDefaultAsync(x => x.UserId == userId
                     && x.Token == token);
         }
-        public async Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(int userId)
+        public async Task<IEnumerable<IUserRefreshToken>> GetRefreshTokensAsync(
+            int userId,
+            bool asNoTracking = true)
         {
-            return await GetRefreshTokensQuery()
+            return await GetRefreshTokensQuery(asNoTracking)
                 .Where(x => x.UserId == userId 
                     && x.Revoked == null)
                 .OrderByDescending(x => x.Expires)
-                .Take(1)
                 .ToListAsync();
         }
         public async Task<IUserRefreshToken> GetOrAddRefreshTokenAsync(int userId)
@@ -299,30 +300,22 @@ namespace aiof.auth.services
                 id);
         }
 
-        public async Task<IUserRefreshToken> RevokeTokenAsync(
-            int userId, 
-            string token)
+        public async Task RevokeAsync(int userId)
         {
-            var refreshToken = await GetRefreshTokenAsync(
-                userId,
-                token,
-                asNoTracking: false)
-                as UserRefreshToken
-                ?? throw new AuthNotFoundException($"{nameof(UserRefreshToken)} with UserId={userId} and Token={token} was not found");
+            var now = DateTime.UtcNow;
+            var refreshTokens = await GetRefreshTokensAsync(userId, false)
+                as IEnumerable<UserRefreshToken>;
 
-            refreshToken.Revoked = DateTime.UtcNow;
-
-            _context.UserRefreshTokens
-                .Update(refreshToken);
+            foreach (var refreshToken in refreshTokens)
+            {
+                refreshToken.Revoked = DateTime.UtcNow;
+            }
 
             await _context.SaveChangesAsync();
 
-            _logger.LogInformation("Revoked {EntityName}={UserRefreshToken} for UserId={UserId}",
+            _logger.LogInformation("Revoked {EntityName}s for UserId={UserId}",
                 nameof(UserRefreshToken),
-                token,
                 userId);
-
-            return refreshToken;
         }
 
         public string Hash(string password)

--- a/aiof.auth.tests/AuthRepository.Tests.cs
+++ b/aiof.auth.tests/AuthRepository.Tests.cs
@@ -117,13 +117,13 @@ namespace aiof.auth.tests
         }
 
         [Fact]
-        public async Task Auth_WithEmptyCredentials_ThrowsAuthValidationException()
+        public async Task Auth_WithEmptyCredentials_ThrowsAuthFriendlyException()
         {
             var repo = new ServiceHelper().GetRequiredService<IAuthRepository>();
 
             var req = new TokenRequest { };
 
-            await Assert.ThrowsAsync<ValidationException>(() => repo.GetTokenAsync(req));
+            await Assert.ThrowsAsync<AuthFriendlyException>(() => repo.GetTokenAsync(req));
         }
 
         [Fact]

--- a/aiof.auth.tests/AuthRepository.Tests.cs
+++ b/aiof.auth.tests/AuthRepository.Tests.cs
@@ -155,20 +155,22 @@ namespace aiof.auth.tests
         }
 
         [Theory]
-        [MemberData(nameof(Helper.ClientRefreshClientIdToken), MemberType = typeof(Helper))]
-        public async Task RevokeTokenAsync_IsSuccessful(
-            int clientId, 
-            string token)
+        [MemberData(nameof(Helper.UserRefreshTokensUserId), MemberType = typeof(Helper))]
+        public async Task RevokeUserAsync_IsSuccessful(int userId)
         {
             var repo = new ServiceHelper().GetRequiredService<IAuthRepository>();
 
-            var revokedTokenResp = await repo.RevokeTokenAsync(token, clientId: clientId);
-
-            Assert.NotNull(revokedTokenResp);
-            Assert.Equal(token, revokedTokenResp.Token);
-            Assert.NotNull(revokedTokenResp.Revoked);
+            await repo.RevokeUserAsync(userId);
         }
 
+        [Theory]
+        [MemberData(nameof(Helper.ClientRefreshTokensClientId), MemberType = typeof(Helper))]
+        public async Task RevokeClientAsync_IsSuccessful(int clientId)
+        {
+            var repo = new ServiceHelper().GetRequiredService<IAuthRepository>();
+
+            await repo.RevokeClientAsync(clientId);
+        }
         
         [Theory]
         [MemberData(nameof(Helper.ClientsApiKey), MemberType = typeof(Helper))]

--- a/aiof.auth.tests/ClientRepository.Tests.cs
+++ b/aiof.auth.tests/ClientRepository.Tests.cs
@@ -75,27 +75,6 @@ namespace aiof.auth.tests
         }
 
         [Theory]
-        [MemberData(nameof(Helper.ClientRefreshClientIdToken), MemberType = typeof(Helper))]
-        public async Task RevokeTokenAsync_IsSuccessful(
-            int clientId, 
-            string token)
-        {
-            var repo = new ServiceHelper().GetRequiredService<IClientRepository>();
-
-            var clientRefreshTokenBefore = await repo.GetRefreshTokenAsync(
-                clientId,
-                token,
-                asNoTracking: true);
-
-            Assert.True(DateTime.UtcNow < clientRefreshTokenBefore.Expires);
-
-            Thread.Sleep(1);
-            var clientRefreshTokenAfter = await repo.RevokeTokenAsync(clientId, token);
-
-            Assert.False(DateTime.UtcNow < clientRefreshTokenAfter.Expires);
-        }
-
-        [Theory]
         [MemberData(nameof(Helper.ClientsId), MemberType = typeof(Helper))]
         public async Task EnableClientAsync_IsSuccessful(int id)
         {

--- a/aiof.auth.tests/Helper.cs
+++ b/aiof.auth.tests/Helper.cs
@@ -192,19 +192,10 @@ namespace aiof.auth.tests
             );
         }
 
-        public static IEnumerable<object[]> UserRefreshTokensUserIdToken()
-        {
-            return _Fake.GetFakeUserRefreshTokensData(
-                userId: true,
-                refreshToken: true
-            );
-        }
-
-        public static IEnumerable<object[]> ClientRefreshClientIdToken()
+        public static IEnumerable<object[]> ClientRefreshTokensClientId()
         {
             return _Fake.GetFakeClientRefreshTokensData(
-                clientId: true,
-                token: true
+                clientId: true
             );
         }
 

--- a/aiof.auth.tests/UserRepository.Tests.cs
+++ b/aiof.auth.tests/UserRepository.Tests.cs
@@ -164,17 +164,6 @@ namespace aiof.auth.tests
             Assert.NotEqual(new DateTime(), refreshToken.Expires);
             Assert.Null(refreshToken.Revoked);
         }
-        [Theory]
-        [MemberData(nameof(Helper.UserRefreshTokensUserIdToken), MemberType = typeof(Helper))]
-        public async Task RevokeTokenAsync_IsSuccessful(int userId, string token)
-        {
-            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IUserRepository>();
-
-            var revokedToken = await repo.RevokeTokenAsync(userId, token);
-
-            Assert.NotNull(revokedToken);
-            Assert.NotNull(revokedToken.Revoked);
-        }
 
         [Theory]
         [MemberData(nameof(Helper.RandomUserDtos), MemberType = typeof(Helper))]

--- a/aiof.auth.tests/Validator.Tests.cs
+++ b/aiof.auth.tests/Validator.Tests.cs
@@ -170,7 +170,7 @@ namespace aiof.auth.tests
                     Email = email,
                     Password = password,
                     ApiKey = apiKey
-                });
+                }, o => o.IncludeAllRuleSets());
 
             Assert.False(validation.IsValid);
         }

--- a/aiof.auth.tests/Validator.Tests.cs
+++ b/aiof.auth.tests/Validator.Tests.cs
@@ -153,6 +153,7 @@ namespace aiof.auth.tests
         }
 
         [Theory]
+        [InlineData("notavalidemail", "pass", null)]
         [InlineData("email@aiof.com", "pass", "apikey")]
         [InlineData("email@aiof.com", null, null)]
         [InlineData(null, "pass", null)]


### PR DESCRIPTION
Closes #21 
Closes #23 

Additionally, it improves the logic behind revoking a User and / or Client access - through refresh tokens. It currently simply sets all of their refresh tokens' revoked timestamp to now. This way they can no longer use them to authenticate.

In the future, we would have to add more functionality to actually disable a User / Client included in the revoke functionality. Much like a full revoke logic.